### PR TITLE
feat: add resend verification email endpoint and UI

### DIFF
--- a/apps/bff/src/common/auth-logging/auth-logging.types.ts
+++ b/apps/bff/src/common/auth-logging/auth-logging.types.ts
@@ -13,6 +13,7 @@ export const AUTH_ACTIONS = [
   'token_refresh',
   'forgot_password',
   'reset_password',
+  'resend_verification_email',
 ] as const
 
 export type AuthAction = (typeof AUTH_ACTIONS)[number]

--- a/apps/bff/src/features/auth/auth.controller.ts
+++ b/apps/bff/src/features/auth/auth.controller.ts
@@ -51,6 +51,12 @@ import {
   type ResetPasswordRequest,
   type ResetPasswordResponse,
 } from '@core/contracts/auth/reset-password'
+import {
+  ResendVerificationEmailRequestSchema,
+  ResendVerificationEmailResponseSchema,
+  type ResendVerificationEmailRequest,
+  type ResendVerificationEmailResponse,
+} from '@core/contracts/auth/resend-verification-email'
 import { ZodBody } from '../../common/validation'
 import { UseCsrfGuard } from '../csrf/csrf.decorator'
 import { CsrfTokenCleanupInterceptor } from '../csrf/csrf-token-cleanup.interceptor'
@@ -356,6 +362,32 @@ export class AuthController {
       async () =>
         ResetPasswordResponseSchema.strip().parse(
           await this.authService.resetPassword(resetPasswordRequest)
+        )
+    )
+  }
+
+  @Post('resend-verification-email')
+  @UseCsrfGuard()
+  @HttpCode(HttpStatus.OK)
+  @ApiOkResponse({
+    description: 'Verification email resent successfully',
+  })
+  @ApiBadRequestResponse({
+    description: 'Validation failed',
+  })
+  async resendVerificationEmail(
+    @Req() req: Request,
+    @ZodBody(ResendVerificationEmailRequestSchema)
+    resendRequest: ResendVerificationEmailRequest
+  ): Promise<ResendVerificationEmailResponse> {
+    // Always returns success to prevent email enumeration.
+    return this.executeWithAuthLogging(
+      req,
+      'resend_verification_email',
+      (statusCode) => (statusCode >= 500 ? 'error' : 'unknown'),
+      async () =>
+        ResendVerificationEmailResponseSchema.strip().parse(
+          await this.authService.resendVerificationEmail(resendRequest)
         )
     )
   }

--- a/apps/bff/src/features/auth/auth.service.ts
+++ b/apps/bff/src/features/auth/auth.service.ts
@@ -17,6 +17,10 @@ import type {
   ResetPasswordRequest,
   ResetPasswordResponse,
 } from '@core/contracts/auth/reset-password'
+import type {
+  ResendVerificationEmailRequest,
+  ResendVerificationEmailResponse,
+} from '@core/contracts/auth/resend-verification-email'
 import { DataSourceFactory } from '../../data-source/data-source.factory'
 import { TokenStorageService } from '../../common/token-management/token-storage.service'
 import { CartIdService } from '../cart-id/cart-id.service'
@@ -114,5 +118,18 @@ export class AuthService {
   ): Promise<ResetPasswordResponse> {
     const { resetPasswordService } = this.dataSourceFactory.getAuthServices()
     return await resetPasswordService.resetPassword(resetPasswordRequest)
+  }
+
+  async resendVerificationEmail(
+    request: ResendVerificationEmailRequest
+  ): Promise<ResendVerificationEmailResponse> {
+    const { generateEmailTokenService } =
+      this.dataSourceFactory.getAuthServices()
+    const result = await generateEmailTokenService.generateEmailToken({
+      email: request.email,
+    })
+    // Always return success to prevent email enumeration.
+    // TODO: remove emailToken once email service is configured.
+    return { success: true, emailToken: result.emailToken }
   }
 }

--- a/apps/presentation/app/query-provider.tsx
+++ b/apps/presentation/app/query-provider.tsx
@@ -52,6 +52,7 @@ const authInvalidationHandlers: Record<
   },
   forgotPassword: () => {},
   resetPassword: () => {},
+  resendVerificationEmail: () => {},
 }
 
 function createQueryClient() {

--- a/apps/presentation/features/auth/auth-confirm-email.tsx
+++ b/apps/presentation/features/auth/auth-confirm-email.tsx
@@ -6,6 +6,7 @@ import { useTranslations } from 'next-intl'
 import Link from 'next/link'
 import { useConfirmEmail } from './hooks/use-confirm-email'
 import { getConfirmEmailErrorTranslationKey } from './lib/error-translations'
+import { ResendVerificationEmailForm } from './auth-resend-verification-email'
 import { LoadingSpinner } from '@/components/ui/loading-spinner'
 import { StandardContainer } from '@/components/ui/standard-container'
 import { ErrorDisplay } from '@/components/ui/error-display'
@@ -19,6 +20,12 @@ export function ConfirmEmail({ onVerified }: ConfirmEmailProps) {
   const t = useTranslations('account.registrationSuccess')
   const searchParams = useSearchParams()
   const { confirmEmailMutation } = useConfirmEmail({ onVerified })
+  const {
+    mutate: confirmEmailMutate,
+    isPending: isMutationPending,
+    isError: isMutationError,
+    data: confirmEmailData,
+  } = confirmEmailMutation
   const hasAttemptedRef = useRef(false)
 
   const token = searchParams.get('token')
@@ -30,21 +37,24 @@ export function ConfirmEmail({ onVerified }: ConfirmEmailProps) {
     }
 
     hasAttemptedRef.current = true
-    confirmEmailMutation.mutate({ tokenValue: token })
+    confirmEmailMutate({ tokenValue: token })
 
     return () => {
       hasAttemptedRef.current = false
     }
-  }, [token, confirmEmailMutation])
+  }, [token, confirmEmailMutate])
 
-  const isError =
-    confirmEmailMutation.isError || confirmEmailMutation.data?.success === false
+  const isError = isMutationError || confirmEmailData?.success === false
+
+  const isExpiredToken = confirmEmailData?.message === 'token_expired'
 
   let displayError: string | null = null
   if (!token) {
     displayError = t('errors.tokenRequired')
+  } else if (isExpiredToken) {
+    displayError = t('errors.tokenExpired')
   } else if (isError) {
-    const errorData = confirmEmailMutation.data
+    const errorData = confirmEmailData
     displayError = t(
       getConfirmEmailErrorTranslationKey(errorData?.statusCode) as any
     )
@@ -62,16 +72,20 @@ export function ConfirmEmail({ onVerified }: ConfirmEmailProps) {
               {displayError}
             </ErrorDisplay>
             <div className='my-4 w-full border-t border-gray-200' />
-            <Link
-              href={signInLink}
-              className='text-center text-sm text-gray-700 underline transition-colors hover:text-gray-900'
-            >
-              {t('backToSignIn')}
-            </Link>
+            {isExpiredToken ? (
+              <ResendVerificationEmailForm />
+            ) : (
+              <Link
+                href={signInLink}
+                className='text-center text-sm text-gray-700 underline transition-colors hover:text-gray-900'
+              >
+                {t('backToSignIn')}
+              </Link>
+            )}
           </>
         )}
 
-        {token !== null && confirmEmailMutation.isPending && (
+        {token !== null && isMutationPending && (
           <LoadingSpinner className='size-8' />
         )}
       </div>

--- a/apps/presentation/features/auth/auth-keys.ts
+++ b/apps/presentation/features/auth/auth-keys.ts
@@ -10,6 +10,8 @@ export const authMutationKeys = {
   confirmEmail: () => [...authMutationKeys.all, 'confirmEmail'] as const,
   forgotPassword: () => [...authMutationKeys.all, 'forgotPassword'] as const,
   resetPassword: () => [...authMutationKeys.all, 'resetPassword'] as const,
+  resendVerificationEmail: () =>
+    [...authMutationKeys.all, 'resendVerificationEmail'] as const,
 }
 
 export type AuthMutationKind =
@@ -19,6 +21,7 @@ export type AuthMutationKind =
   | 'confirmEmail'
   | 'forgotPassword'
   | 'resetPassword'
+  | 'resendVerificationEmail'
 
 export function isAuthMutationKey(
   key: unknown
@@ -33,6 +36,7 @@ export function isAuthMutationKey(
       'confirmEmail',
       'forgotPassword',
       'resetPassword',
+      'resendVerificationEmail',
     ].includes(String(key[1]))
   )
 }

--- a/apps/presentation/features/auth/auth-login-form.tsx
+++ b/apps/presentation/features/auth/auth-login-form.tsx
@@ -16,6 +16,9 @@ import { zodResolver } from '@hookform/resolvers/zod'
 import { Toast, addToast } from '@/components/ui/toast'
 import { HttpError } from '@/lib/error-utils'
 import { useLogin } from './hooks/use-login'
+import { useResendVerificationEmail } from './hooks/use-resend-verification-email'
+// TODO: Remove once email service provider is configured.
+import { TemporaryVerifyEmailButton } from './auth-temporary-verify-email-button'
 
 interface LoginFormProps {
   onSuccess?: () => void
@@ -24,8 +27,11 @@ interface LoginFormProps {
 export function LoginForm({ onSuccess }: LoginFormProps) {
   const t = useTranslations('account.signIn')
   const { loginMutation } = useLogin()
+  const { resendVerificationEmailMutation } = useResendVerificationEmail()
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
   const [showErrorToast, setShowErrorToast] = useState(false)
+  const [emailNotVerified, setEmailNotVerified] = useState(false)
+  const [verifyEmailHref, setVerifyEmailHref] = useState<string | null>(null)
 
   const form = useForm<LoginRequest>({
     resolver: zodResolver(LoginRequestSchema),
@@ -36,6 +42,8 @@ export function LoginForm({ onSuccess }: LoginFormProps) {
   })
 
   async function onSubmit(data: LoginRequest) {
+    setEmailNotVerified(false)
+    setVerifyEmailHref(null)
     const result = await loginMutation.mutateAsync(data)
     if (!result.success) {
       setErrorMessage(
@@ -47,6 +55,13 @@ export function LoginForm({ onSuccess }: LoginFormProps) {
       return
     }
     const response = result.data
+    if (
+      !response.success &&
+      response.errorTranslationKey === 'errors.emailNotVerified'
+    ) {
+      setEmailNotVerified(true)
+      return
+    }
     if (!response.success && response.errorTranslationKey) {
       setErrorMessage(
         t(response.errorTranslationKey as Parameters<typeof t>[0])
@@ -62,8 +77,60 @@ export function LoginForm({ onSuccess }: LoginFormProps) {
     onSuccess?.()
   }
 
+  async function onResendVerificationEmail() {
+    const email = form.getValues('email')
+    const result = await resendVerificationEmailMutation.mutateAsync({ email })
+    if (!result.success) {
+      addToast({
+        type: 'error',
+        children: HttpError.isTooManyRequestsError(result.error)
+          ? t('errors.tooManyRequests')
+          : t('errors.resendFailed'),
+      })
+      return
+    }
+    if (result.data.emailToken) {
+      setVerifyEmailHref(
+        `/sign-up/verify-email?token=${result.data.emailToken}`
+      )
+    }
+  }
+
   return (
     <div className='flex w-full flex-col content-stretch gap-6'>
+      {emailNotVerified && (
+        <div className='flex flex-col gap-3'>
+          <Toast
+            type='error'
+            withCloseButton={false}
+            withIcon={false}
+            className='max-w-full sm:max-w-full'
+          >
+            <div className='flex flex-col gap-2'>
+              <span>{t('errors.emailNotVerified')}</span>
+              {!verifyEmailHref && (
+                <Button
+                  type='button'
+                  variant='tertiary'
+                  className='h-auto justify-start p-0 text-sm underline'
+                  disabled={resendVerificationEmailMutation.isPending}
+                  onClick={onResendVerificationEmail}
+                >
+                  {resendVerificationEmailMutation.isPending
+                    ? t('resendPending')
+                    : t('resendButton')}
+                </Button>
+              )}
+            </div>
+          </Toast>
+          {verifyEmailHref && (
+            <TemporaryVerifyEmailButton
+              href={verifyEmailHref}
+              label={t('verifyEmailButton')}
+            />
+          )}
+        </div>
+      )}
       {showErrorToast && errorMessage && (
         <Toast
           type='error'

--- a/apps/presentation/features/auth/auth-registration-success.tsx
+++ b/apps/presentation/features/auth/auth-registration-success.tsx
@@ -1,9 +1,8 @@
 'use client'
 
 import { useTranslations } from 'next-intl'
-import Link from 'next/link'
-import { Button } from '@/components/ui/button'
-import { Toast } from '@/components/ui/toast'
+// TODO: Remove once email service provider is configured.
+import { TemporaryVerifyEmailButton } from './auth-temporary-verify-email-button'
 
 interface RegistrationSuccessProps {
   /** Verify-email link. Page is responsible for building the URL. */
@@ -23,20 +22,10 @@ export function RegistrationSuccess({
       </div>
 
       <div className='flex w-full flex-col gap-4'>
-        <Toast
-          type='warning'
-          withCloseButton={false}
-        >
-          Button and link are temporary until email service provider is set up
-        </Toast>
-        <Button
-          asChild
-          variant='primary'
-          scheme='red'
-          className='w-full uppercase'
-        >
-          <Link href={verifyEmailHref}>{t('confirmButton')}</Link>
-        </Button>
+        <TemporaryVerifyEmailButton
+          href={verifyEmailHref}
+          label={t('confirmButton')}
+        />
       </div>
     </div>
   )

--- a/apps/presentation/features/auth/auth-resend-verification-email.tsx
+++ b/apps/presentation/features/auth/auth-resend-verification-email.tsx
@@ -1,0 +1,104 @@
+'use client'
+
+import { useState } from 'react'
+import { useTranslations } from 'next-intl'
+import { useForm, Controller } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useResendVerificationEmail } from './hooks/use-resend-verification-email'
+import { Button } from '@/components/ui/button'
+import { Field, FieldError } from '@/components/ui/field'
+import { TextInput } from '@/components/ui/inputs/text-input'
+// TODO: Remove once email service provider is configured.
+import { TemporaryVerifyEmailButton } from './auth-temporary-verify-email-button'
+import {
+  ResendVerificationEmailRequestSchema,
+  type ResendVerificationEmailRequest,
+} from '@core/contracts/auth/resend-verification-email'
+
+export function ResendVerificationEmailForm() {
+  const t = useTranslations('account.registrationSuccess')
+  const { resendVerificationEmailMutation } = useResendVerificationEmail()
+  const [success, setSuccess] = useState(false)
+  const [error, setError] = useState(false)
+  const [verifyEmailHref, setVerifyEmailHref] = useState<string | null>(null)
+
+  const form = useForm<ResendVerificationEmailRequest>({
+    resolver: zodResolver(ResendVerificationEmailRequestSchema),
+    defaultValues: { email: '' },
+  })
+
+  async function onSubmit(data: ResendVerificationEmailRequest) {
+    setError(false)
+    setVerifyEmailHref(null)
+    const result = await resendVerificationEmailMutation.mutateAsync(data)
+    if (!result.success) {
+      setError(true)
+      return
+    }
+    if (result.data.emailToken) {
+      setVerifyEmailHref(
+        `/sign-up/verify-email?token=${result.data.emailToken}`
+      )
+    }
+    setSuccess(true)
+  }
+
+  if (success) {
+    return (
+      <div className='flex w-full flex-col gap-4'>
+        <p className='text-center text-sm text-gray-700'>
+          {t('resendSuccess')}
+        </p>
+        {verifyEmailHref && (
+          <TemporaryVerifyEmailButton
+            href={verifyEmailHref}
+            label={t('confirmButton')}
+          />
+        )}
+      </div>
+    )
+  }
+
+  return (
+    <form
+      onSubmit={form.handleSubmit(onSubmit)}
+      className='flex w-full flex-col gap-2'
+      noValidate
+    >
+      <Controller
+        name='email'
+        control={form.control}
+        render={({ field, fieldState }) => (
+          <Field data-invalid={fieldState.invalid}>
+            <TextInput
+              {...field}
+              id='resend-email'
+              label={t('resendEmailLabel')}
+              required
+              autoComplete='email'
+            />
+            {fieldState.invalid && fieldState.error && (
+              <FieldError error={fieldState.error} />
+            )}
+          </Field>
+        )}
+      />
+      {error && (
+        <p className='text-sm text-red-600'>{t('errors.resendFailed')}</p>
+      )}
+      <Button
+        type='submit'
+        variant='primary'
+        disabled={
+          form.formState.isSubmitting ||
+          resendVerificationEmailMutation.isPending
+        }
+      >
+        {form.formState.isSubmitting ||
+        resendVerificationEmailMutation.isPending
+          ? t('resendPending')
+          : t('resendButton')}
+      </Button>
+    </form>
+  )
+}

--- a/apps/presentation/features/auth/auth-temporary-verify-email-button.tsx
+++ b/apps/presentation/features/auth/auth-temporary-verify-email-button.tsx
@@ -1,0 +1,33 @@
+import Link from 'next/link'
+import { Button } from '@/components/ui/button'
+import { Toast } from '@/components/ui/toast'
+
+interface TemporaryVerifyEmailButtonProps {
+  href: string
+  label: string
+}
+
+// TODO: Remove once email service provider is configured.
+export function TemporaryVerifyEmailButton({
+  href,
+  label,
+}: TemporaryVerifyEmailButtonProps) {
+  return (
+    <>
+      <Toast
+        type='warning'
+        withCloseButton={false}
+      >
+        Button and link are temporary until email service provider is set up
+      </Toast>
+      <Button
+        asChild
+        variant='primary'
+        scheme='red'
+        className='w-full uppercase'
+      >
+        <Link href={href}>{label}</Link>
+      </Button>
+    </>
+  )
+}

--- a/apps/presentation/features/auth/hooks/use-resend-verification-email.ts
+++ b/apps/presentation/features/auth/hooks/use-resend-verification-email.ts
@@ -1,0 +1,26 @@
+'use client'
+
+import { useBffClientMutation } from '@/lib/bff/utils/mutations'
+import { authMutationKeys } from '../auth-keys'
+import { useAuthService } from './use-auth-service'
+import type {
+  ResendVerificationEmailRequest,
+  ResendVerificationEmailResponse,
+} from '@core/contracts/auth/resend-verification-email'
+
+export function useResendVerificationEmail() {
+  const { authService } = useAuthService()
+
+  const resendVerificationEmailMutation = useBffClientMutation({
+    mutationKey: authMutationKeys.resendVerificationEmail(),
+    // null = no automatic toast; caller handles feedback
+    errorMessage: null,
+    mutationFn: async (
+      request: ResendVerificationEmailRequest
+    ): Promise<ResendVerificationEmailResponse> => {
+      return await authService.resendVerificationEmail(request)
+    },
+  })
+
+  return { resendVerificationEmailMutation }
+}

--- a/apps/presentation/features/auth/lib/auth-bff-service.ts
+++ b/apps/presentation/features/auth/lib/auth-bff-service.ts
@@ -16,6 +16,10 @@ import {
   ResetPasswordRequest,
   ResetPasswordResponse,
 } from '@core/contracts/auth/reset-password'
+import {
+  ResendVerificationEmailRequest,
+  ResendVerificationEmailResponse,
+} from '@core/contracts/auth/resend-verification-email'
 import { BaseService } from '@/lib/bff/services/base-service'
 
 /**
@@ -71,6 +75,19 @@ export class AuthService extends BaseService {
       request,
       {
         onError: (res) => handleErrorResponse<ResetPasswordResponse>(res),
+      }
+    )
+  }
+
+  async resendVerificationEmail(
+    request: ResendVerificationEmailRequest
+  ): Promise<ResendVerificationEmailResponse> {
+    return await this.post<ResendVerificationEmailResponse>(
+      '/auth/resend-verification-email',
+      request,
+      {
+        onError: (res) =>
+          handleErrorResponse<ResendVerificationEmailResponse>(res),
       }
     )
   }

--- a/config/constants/src/auth.ts
+++ b/config/constants/src/auth.ts
@@ -37,6 +37,11 @@ export const CSRF_TOKEN_CONFIG = {
 export const ACCESS_TOKEN_TOKEN = 'ACCESS_TOKEN_TOKEN'
 
 /**
+ * TTL for email verification tokens (in minutes)
+ */
+export const EMAIL_TOKEN_TTL_MINUTES = 60
+
+/**
  * TTL for password reset tokens (in minutes)
  */
 export const PASSWORD_RESET_TOKEN_TTL_MINUTES = 60

--- a/core/contracts/src/auth/resend-verification-email.ts
+++ b/core/contracts/src/auth/resend-verification-email.ts
@@ -1,0 +1,21 @@
+import { z } from 'zod'
+
+export const ResendVerificationEmailRequestSchema = z.object({
+  email: z.email(),
+})
+
+export type ResendVerificationEmailRequest = z.infer<
+  typeof ResendVerificationEmailRequestSchema
+>
+
+export const ResendVerificationEmailResponseSchema = z.object({
+  success: z.boolean(),
+  // TODO: remove emailToken once email service is configured.
+  emailToken: z.string().optional(),
+  statusCode: z.number().optional(),
+  message: z.string().optional(),
+})
+
+export type ResendVerificationEmailResponse = z.infer<
+  typeof ResendVerificationEmailResponseSchema
+>

--- a/core/i18n/de-DE.json
+++ b/core/i18n/de-DE.json
@@ -270,9 +270,14 @@
         "validationFailed": "Validierung fehlgeschlagen",
         "unauthorized": "Anmeldung fehlgeschlagen. Bitte überprüfen Sie Ihre Anmeldedaten und versuchen Sie es erneut.",
         "emailNotVerified": "Bitte bestätigen Sie Ihre E-Mail-Adresse, bevor Sie sich anmelden. Überprüfen Sie Ihren Posteingang auf eine Bestätigungs-E-Mail.",
+        "resendFailed": "Bestätigungs-E-Mail konnte nicht gesendet werden. Bitte versuchen Sie es erneut.",
         "forbidden": "Zugriff verweigert. Bitte aktualisieren Sie die Seite und versuchen Sie es erneut.",
         "internalServerError": "Interner Serverfehler"
-      }
+      },
+      "resendButton": "Bestätigungs-E-Mail erneut senden",
+      "resendPending": "Wird gesendet...",
+      "resendSuccess": "Bestätigungs-E-Mail gesendet. Bitte überprüfen Sie Ihren Posteingang.",
+      "verifyEmailButton": "E-Mail bestätigen"
     },
     "signUp": {
       "title": "Registrieren",
@@ -326,8 +331,15 @@
       "confirmedMessage": "Ihre E-Mail wurde erfolgreich bestätigt!",
       "continueButton": "Weiter zur Anmeldung",
       "backToSignIn": "Zurück zur Anmeldung",
+      "registerAgain": "Erneut registrieren",
+      "resendEmailLabel": "Ihre E-Mail-Adresse",
+      "resendButton": "Bestätigungs-E-Mail erneut senden",
+      "resendPending": "Wird gesendet...",
+      "resendSuccess": "Bestätigungs-E-Mail gesendet. Bitte prüfen Sie Ihren Posteingang.",
       "errors": {
         "tokenRequired": "E-Mail-Bestätigungstoken ist erforderlich. Bitte verwenden Sie den Link aus Ihrer E-Mail.",
+        "tokenExpired": "Ihr Bestätigungslink ist abgelaufen. Geben Sie Ihre E-Mail-Adresse ein, um einen neuen zu erhalten.",
+        "resendFailed": "Bestätigungs-E-Mail konnte nicht gesendet werden. Bitte versuchen Sie es erneut.",
         "confirmFailed": "E-Mail-Bestätigung fehlgeschlagen. Bitte versuchen Sie es erneut oder verwenden Sie den Link aus Ihrer E-Mail.",
         "validationFailed": "Bitte überprüfen Sie Ihre Eingabe",
         "unauthorized": "Ungültiger Bestätigungstoken",

--- a/core/i18n/en-US.json
+++ b/core/i18n/en-US.json
@@ -271,9 +271,14 @@
         "validationFailed": "Validation failed",
         "unauthorized": "Login failed. Please check your credentials and try again.",
         "emailNotVerified": "Please verify your email address before logging in. Check your inbox for a confirmation email.",
+        "resendFailed": "Failed to resend verification email. Please try again.",
         "forbidden": "Access denied. Please refresh the page and try again.",
         "internalServerError": "Internal server error"
-      }
+      },
+      "resendButton": "Resend verification email",
+      "resendPending": "Sending...",
+      "resendSuccess": "Verification email sent. Please check your inbox.",
+      "verifyEmailButton": "Verify email"
     },
     "signUp": {
       "title": "Register",
@@ -327,8 +332,15 @@
       "confirmedMessage": "Your email has been confirmed successfully!",
       "continueButton": "Continue to Sign In",
       "backToSignIn": "Back to Sign In",
+      "registerAgain": "Register again",
+      "resendEmailLabel": "Your email address",
+      "resendButton": "Resend verification email",
+      "resendPending": "Sending...",
+      "resendSuccess": "Verification email sent. Please check your inbox.",
       "errors": {
         "tokenRequired": "Email verification token is required. Please use the link from your email.",
+        "tokenExpired": "Your verification link has expired. Enter your email to receive a new one.",
+        "resendFailed": "Failed to resend verification email. Please try again.",
         "confirmFailed": "Failed to confirm email. Please try again or use the link from your email.",
         "validationFailed": "Please check your input",
         "unauthorized": "Invalid verification token",

--- a/integrations/commercetools-auth/src/services/confirm-email.service.ts
+++ b/integrations/commercetools-auth/src/services/confirm-email.service.ts
@@ -1,32 +1,53 @@
 import { Injectable } from '@nestjs/common'
+import { PinoLogger } from 'nestjs-pino'
 import { ServerClientService } from '@integrations/commercetools-api'
 import type {
   ConfirmEmailRequest,
   ConfirmEmailResponse,
 } from '@core/contracts/auth/confirm-email'
+import { CommercetoolsErrorMatcher } from '../utils/commercetools-error-matcher'
 
 @Injectable()
 export class CommercetoolsConfirmEmailService {
-  constructor(private readonly serverClientService: ServerClientService) {}
+  constructor(
+    private readonly serverClientService: ServerClientService,
+    private readonly logger: PinoLogger,
+    private readonly errorMatcher: CommercetoolsErrorMatcher
+  ) {
+    this.logger.setContext(CommercetoolsConfirmEmailService.name)
+  }
 
   async confirmEmail(
     confirmEmailRequest: ConfirmEmailRequest
   ): Promise<ConfirmEmailResponse> {
     const client = this.serverClientService.getClient()
 
-    const response = await client
-      .customers()
-      .emailConfirm()
-      .post({
-        body: {
-          tokenValue: confirmEmailRequest.tokenValue,
-        },
-      })
-      .execute()
+    try {
+      const response = await client
+        .customers()
+        .emailConfirm()
+        .post({
+          body: {
+            tokenValue: confirmEmailRequest.tokenValue,
+          },
+        })
+        .execute()
 
-    const customer = response.body
-    const alreadyVerified = customer?.isEmailVerified === true
+      const customer = response.body
+      const alreadyVerified = customer?.isEmailVerified === true
 
-    return { success: true, alreadyVerified }
+      return { success: true, alreadyVerified }
+    } catch (error) {
+      if (this.errorMatcher.isExpiredEmailTokenError(error)) {
+        return { success: false, statusCode: 400, message: 'token_expired' }
+      }
+
+      if (this.errorMatcher.isInvalidTokenError(error)) {
+        return { success: false, statusCode: 400 }
+      }
+
+      this.logger.error({ err: error }, 'Error confirming email')
+      return { success: false }
+    }
   }
 }

--- a/integrations/commercetools-auth/src/services/generate-email-token.service.ts
+++ b/integrations/commercetools-auth/src/services/generate-email-token.service.ts
@@ -5,6 +5,7 @@ import type {
   GenerateEmailTokenRequest,
   GenerateEmailTokenResponse,
 } from '@core/contracts/auth/generate-email-token'
+import { EMAIL_TOKEN_TTL_MINUTES } from '@config/constants'
 
 @Injectable()
 export class CommercetoolsGenerateEmailTokenService {
@@ -57,7 +58,7 @@ export class CommercetoolsGenerateEmailTokenService {
         .post({
           body: {
             id: customer.id,
-            ttlMinutes: 60,
+            ttlMinutes: EMAIL_TOKEN_TTL_MINUTES,
           },
         })
         .execute()

--- a/integrations/commercetools-auth/src/utils/commercetools-error-matcher.ts
+++ b/integrations/commercetools-auth/src/utils/commercetools-error-matcher.ts
@@ -70,6 +70,20 @@ export class CommercetoolsErrorMatcher {
     )
   }
 
+  isExpiredEmailTokenError(error: unknown): boolean {
+    if (!this.isHttpError(error)) {
+      return false
+    }
+
+    return (
+      error.statusCode === 400 &&
+      (error.body?.errors?.some(
+        (e) => e.code === 'ExpiredCustomerEmailToken'
+      ) ??
+        false)
+    )
+  }
+
   isDuplicateEmailError(error: unknown): boolean {
     if (!this.isHttpError(error)) {
       return false


### PR DESCRIPTION
- ResendVerificationEmailForm shown on confirm-email page when token is expired
- Resend button shown on login form when email is not verified
- CommercetoolsConfirmEmailService now handles token_expired and invalid_token errors distinctly
- EMAIL_TOKEN_TTL_MINUTES constant extracted from hardcoded 60-minute value