### PR TITLE
docs: rename project to SHOPin storefront accelerator

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # =============================================================================
-# SHOPin storefront starter – environment template
+# SHOPin storefront accelerator – environment template
 # =============================================================================
 # Copy this file to .env and set values. Do not commit .env or real secrets.
 # All variables are read from the repository root .env by BFF and presentation.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Thank you for your interest in contributing to the SHOPin storefront starter.
+Thank you for your interest in contributing to the SHOPin storefront accelerator.
 
 ## Development setup
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-# SHOPin storefront starter
+# SHOPin storefront accelerator
 
 [![License: OSL-3.0](https://img.shields.io/badge/License-OSL--3.0-blue.svg)](https://opensource.org/licenses/OSL-3.0)
 
-A modular storefront starter with a NestJS Backend for Frontend (BFF), Next.js presentation app, and pluggable data sources. Swap e-commerce backends and CMSs via a data-source layer; built for flexibility and type-safe development in a monorepo. **[Turborepo](https://turbo.build/repo)** orchestrates the monorepo: builds, tasks, and caching across all apps and packages.
+A modular storefront accelerator with a NestJS Backend for Frontend (BFF), Next.js presentation app, and pluggable data sources. Swap e-commerce backends and CMSs via a data-source layer; built for flexibility and type-safe development in a monorepo. **[Turborepo](https://turbo.build/repo)** orchestrates the monorepo: builds, tasks, and caching across all apps and packages.
 
 ## Features
 
 - **BFF + storefront** — Clear separation between API gateway (NestJS) and frontend (Next.js App Router). Suits any e-commerce or CMS backend you wire behind the BFF.
-- **Pluggable data sources** — Switch backends (e.g. e-commerce API, mock) and optionally attach a CMS for pages and layout. The starter ships with one integration set; you can add or replace integrations.
+- **Pluggable data sources** — Switch backends (e.g. e-commerce API, mock) and optionally attach a CMS for pages and layout. SHOPin ships with one integration set; you can add or replace integrations.
 - **Turborepo** — [Turborepo](https://turbo.build/repo) orchestrates builds, tasks, and caching across the monorepo. Shared packages for contracts, i18n, config, and tooling.
 - **Demo tooling** — Optional data-source selector and mocked flows for development; safe to remove for production.
 - **Documentation** — [Storybook](apps/storybook/README.md) for UI components, [Typedoc](apps/typedoc/README.md) for API docs.
@@ -20,7 +20,7 @@ A modular storefront starter with a NestJS Backend for Frontend (BFF), Next.js p
 
    ```bash
    git clone <repository-url>
-   cd starter
+   cd shopin
    npm ci
    ```
 

--- a/apps/bff/README.md
+++ b/apps/bff/README.md
@@ -1,6 +1,6 @@
 # @apps/bff
 
-NestJS Backend for Frontend (BFF) for the SHOPin storefront starter. Exposes a unified REST API for products, cart, checkout, auth, content, and navigation; routes requests to [integrations](../../integrations) (e.g. Commercetools, Contentful, mock) based on the selected data source.
+NestJS Backend for Frontend (BFF) for the SHOPin storefront accelerator. Exposes a unified REST API for products, cart, checkout, auth, content, and navigation; routes requests to [integrations](../../integrations) (e.g. Commercetools, Contentful, mock) based on the selected data source.
 
 ## Overview
 

--- a/apps/presentation/README.md
+++ b/apps/presentation/README.md
@@ -1,6 +1,6 @@
 # @apps/presentation
 
-Next.js (App Router) storefront UI for the SHOPin storefront starter. Renders product catalog, cart, checkout, auth, and CMS-driven pages; talks to the BFF for all e-commerce and content APIs.
+Next.js (App Router) storefront UI for the SHOPin storefront accelerator. Renders product catalog, cart, checkout, auth, and CMS-driven pages; talks to the BFF for all e-commerce and content APIs.
 
 ## Environment Variables
 

--- a/core/contracts/README.md
+++ b/core/contracts/README.md
@@ -1,6 +1,6 @@
 # @core/contracts
 
-Shared TypeScript interfaces, types, and Zod schemas used across the SHOPin storefront starter (BFF, presentation, and integrations). Single source of truth for API contracts and domain types.
+Shared TypeScript interfaces, types, and Zod schemas used across the SHOPin storefront accelerator (BFF, presentation, and integrations). Single source of truth for API contracts and domain types.
 
 **Objects in general should be defined here** — use this package for interfaces, object-shaped types, and API/domain contracts. For primitive constants and small derived types (e.g. from `as const`), use `@config/constants` instead.
 

--- a/demo/README.md
+++ b/demo/README.md
@@ -1,6 +1,6 @@
 # Demo Workspace
 
-⚠️ **DEMO ONLY** — This workspace contains optional demo packages for the SHOPin storefront starter. None of these packages are required for production.
+⚠️ **DEMO ONLY** — This workspace contains optional demo packages for the SHOPin storefront accelerator. None of these packages are required for production.
 
 Demo functionality showcases multi–data-source switching and mocked payment; you can remove this entire workspace when building a production storefront.
 

--- a/integrations/commercetools-api/README.md
+++ b/integrations/commercetools-api/README.md
@@ -1,6 +1,6 @@
 # @integrations/commercetools-api
 
-NestJS module that integrates [Commercetools](https://commercetools.com/) with the SHOPin storefront starter. Implements product catalog, cart, checkout, navigation, and customer services against the Commercetools API.
+NestJS module that integrates [Commercetools](https://commercetools.com/) with the SHOPin storefront accelerator. Implements product catalog, cart, checkout, navigation, and customer services against the Commercetools API.
 
 ## Overview
 

--- a/integrations/commercetools-auth/README.md
+++ b/integrations/commercetools-auth/README.md
@@ -1,6 +1,6 @@
 # @integrations/commercetools-auth
 
-NestJS module that handles customer authentication and registration via [Commercetools](https://commercetools.com/) for the SHOPin storefront starter. Provides login, registration, password reset, email verification, and anonymous sessions.
+NestJS module that handles customer authentication and registration via [Commercetools](https://commercetools.com/) for the SHOPin storefront accelerator. Provides login, registration, password reset, email verification, and anonymous sessions.
 
 ## Overview
 

--- a/integrations/contentful-api/README.md
+++ b/integrations/contentful-api/README.md
@@ -1,6 +1,6 @@
 # @integrations/contentful-api
 
-NestJS module that integrates [Contentful](https://www.contentful.com/) with the SHOPin storefront starter for CMS content. Provides `PageService` (pages by slug/locale/preview) and `LayoutService` (header/footer) via the Contentful GraphQL API.
+NestJS module that integrates [Contentful](https://www.contentful.com/) with the SHOPin storefront accelerator for CMS content. Provides `PageService` (pages by slug/locale/preview) and `LayoutService` (header/footer) via the Contentful GraphQL API.
 
 ## Overview
 

--- a/integrations/contentful-migration/README.md
+++ b/integrations/contentful-migration/README.md
@@ -1,6 +1,6 @@
 # @integrations/contentful-migration
 
-Content model and demo content for the SHOPin storefront starter, applied via [Contentful migrations](https://contentful.com/developers/docs/tutorials/cli/scripting-migrations/) (CMS-as-code). Defines content types (Page, teasers, layout, etc.) and optional seed data; run against your Contentful space so the BFF and `@integrations/contentful-api` can serve pages and layout.
+Content model and demo content for the SHOPin storefront accelerator, applied via [Contentful migrations](https://contentful.com/developers/docs/tutorials/cli/scripting-migrations/) (CMS-as-code). Defines content types (Page, teasers, layout, etc.) and optional seed data; run against your Contentful space so the BFF and `@integrations/contentful-api` can serve pages and layout.
 
 ## Prerequisites
 

--- a/integrations/mock-api/README.md
+++ b/integrations/mock-api/README.md
@@ -1,6 +1,6 @@
 # @integrations/mock-api
 
-NestJS module that provides mock implementations of the SHOPin storefront starter data-source services. Used for local development, demos, and testing when the data source is `mock-set` (no Commercetools or Contentful required).
+NestJS module that provides mock implementations of the SHOPin storefront accelerator data-source services. Used for local development, demos, and testing when the data source is `mock-set` (no Commercetools or Contentful required).
 
 ## Overview
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "shopin",
   "version": "0.1.0",
-  "description": "Modular SHOPin storefront starter with BFF, Next.js presentation, and multi-data-source support",
+  "description": "Modular SHOPin storefront accelerator with BFF, Next.js presentation, and multi-data-source support",
   "author": "creativestyle GmbH",
   "license": "OSL-3.0",
   "private": true,


### PR DESCRIPTION
- Replace "starter" with "shopin" / "SHOPin storefront" across READMEs
- Add "storefront accelerator" in root README, package.json, CONTRIBUTING, .env.example, and package READMEs (bff, presentation, integrations, core, demo)
- Update quick start to use `cd shopin`