### PR TITLE
refactor: extract PageShell/PageContent components and fix sticky footer layout

### DIFF
--- a/apps/presentation/app/[locale]/(main)/layout.tsx
+++ b/apps/presentation/app/[locale]/(main)/layout.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { Header } from '../../../components/layout/header'
 import { Footer } from '../../../components/layout/footer'
+import { PageShell, PageContent } from '../../../components/layout/page-shell'
 
 export default function MainLayout({
   children,
@@ -8,10 +9,10 @@ export default function MainLayout({
   children: React.ReactNode
 }) {
   return (
-    <>
+    <PageShell>
       <Header />
-      <main>{children}</main>
+      <PageContent>{children}</PageContent>
       <Footer />
-    </>
+    </PageShell>
   )
 }

--- a/apps/presentation/app/[locale]/checkout/(regular)/layout.tsx
+++ b/apps/presentation/app/[locale]/checkout/(regular)/layout.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { Header } from '@/components/layout/header'
 import { Footer } from '@/components/layout/footer'
+import { PageShell, PageContent } from '@/components/layout/page-shell'
 
 export default function CheckoutRegularLayout({
   children,
@@ -8,10 +9,10 @@ export default function CheckoutRegularLayout({
   children: React.ReactNode
 }) {
   return (
-    <>
+    <PageShell>
       <Header />
-      <main>{children}</main>
+      <PageContent>{children}</PageContent>
       <Footer />
-    </>
+    </PageShell>
   )
 }

--- a/apps/presentation/app/[locale]/checkout/(steps)/layout.tsx
+++ b/apps/presentation/app/[locale]/checkout/(steps)/layout.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { CheckoutHeader } from '@/features/checkout/checkout-header'
 import { CheckoutFooter } from '@/features/checkout/checkout-footer'
+import { PageShell, PageContent } from '@/components/layout/page-shell'
 
 export default function CheckoutStepsLayout({
   children,
@@ -8,10 +9,10 @@ export default function CheckoutStepsLayout({
   children: React.ReactNode
 }) {
   return (
-    <div className='flex min-h-screen flex-col bg-gray-50'>
+    <PageShell className='bg-gray-50'>
       <CheckoutHeader />
-      <main className='flex flex-1 flex-col'>{children}</main>
+      <PageContent className='flex flex-col'>{children}</PageContent>
       <CheckoutFooter />
-    </div>
+    </PageShell>
   )
 }

--- a/apps/presentation/app/[locale]/checkout/payment/layout.tsx
+++ b/apps/presentation/app/[locale]/checkout/payment/layout.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { CheckoutHeader } from '@/features/checkout/checkout-header'
 import { CheckoutFooter } from '@/features/checkout/checkout-footer'
+import { PageShell, PageContent } from '@/components/layout/page-shell'
 
 export default function PaymentLayout({
   children,
@@ -8,10 +9,10 @@ export default function PaymentLayout({
   children: React.ReactNode
 }) {
   return (
-    <div className='flex min-h-screen flex-col bg-gray-50'>
+    <PageShell className='bg-gray-50'>
       <CheckoutHeader />
-      <main className='flex flex-1 flex-col'>{children}</main>
+      <PageContent className='flex flex-col'>{children}</PageContent>
       <CheckoutFooter />
-    </div>
+    </PageShell>
   )
 }

--- a/apps/presentation/app/[locale]/layout.tsx
+++ b/apps/presentation/app/[locale]/layout.tsx
@@ -29,8 +29,10 @@ export default async function LocaleLayout({
     >
       <StoreConfigProvider storeConfig={storeConfig}>
         <AddToCartModalProvider>
-          <TopBar messages={headerLayout?.topBarMessages ?? []} />
-          <main>{children}</main>
+          <div className='flex min-h-screen flex-col'>
+            <TopBar messages={headerLayout?.topBarMessages ?? []} />
+            {children}
+          </div>
           <Toaster position='bottom-right' />
           <DemoDisclaimerModal />
         </AddToCartModalProvider>

--- a/apps/presentation/components/layout/page-shell.tsx
+++ b/apps/presentation/components/layout/page-shell.tsx
@@ -1,0 +1,22 @@
+import React from 'react'
+import { cn } from '@/lib/utils'
+
+export function PageShell({
+  children,
+  className,
+}: {
+  children: React.ReactNode
+  className?: string
+}) {
+  return <div className={cn('flex flex-1 flex-col', className)}>{children}</div>
+}
+
+export function PageContent({
+  children,
+  className,
+}: {
+  children: React.ReactNode
+  className?: string
+}) {
+  return <main className={cn('flex-1', className)}>{children}</main>
+}


### PR DESCRIPTION
Replace duplicated flex wrappers across main and checkout layouts with shared PageShell/PageContent components. Root locale layout now owns min-h-screen, enabling child layouts to inherit flex-1 and push the footer to the bottom.