### PR TITLE
feat: add size variant to Button component and migrate all raw buttons

### DIFF
--- a/apps/presentation/app/globals.css
+++ b/apps/presentation/app/globals.css
@@ -147,6 +147,11 @@
     margin-left: auto;
     margin-right: auto;
   }
+
+  button:not(:disabled),
+  [role='button']:not(:disabled) {
+    cursor: pointer;
+  }
 }
 
 @layer utilities {

--- a/apps/presentation/components/layout/header-search-button.tsx
+++ b/apps/presentation/components/layout/header-search-button.tsx
@@ -12,6 +12,7 @@ export function HeaderSearchButton() {
   return (
     <>
       <button
+        type='button'
         onClick={() => setIsSearchOpen(true)}
         className='p-1 text-gray-900 hover:bg-gray-100 hover:text-primary'
       >

--- a/apps/presentation/components/layout/header.tsx
+++ b/apps/presentation/components/layout/header.tsx
@@ -21,7 +21,7 @@ export async function Header() {
             <div className='flex items-center gap-2'>
               <NavigationMobileMenu />
               <MobileAccountLink
-                className='p-1 text-gray-900 hover:bg-gray-100 hover:text-primary'
+                className='inline-flex items-center p-1 text-gray-900 hover:bg-gray-100 hover:text-primary'
                 aria-label={t('account')}
               />
             </div>

--- a/apps/presentation/components/layout/locale-switcher.tsx
+++ b/apps/presentation/components/layout/locale-switcher.tsx
@@ -95,6 +95,7 @@ export function LocaleSwitcher() {
     <div className='relative'>
       <button
         ref={buttonRef}
+        type='button'
         onClick={(e) => {
           e.stopPropagation()
           setIsOpen(!isOpen)

--- a/apps/presentation/components/layout/search-popup.tsx
+++ b/apps/presentation/components/layout/search-popup.tsx
@@ -37,6 +37,7 @@ function SuggestionItem({
   return (
     <li>
       <button
+        type='button'
         onClick={onClick}
         className='flex cursor-pointer items-center gap-2 text-left text-sm text-gray-700 hover:text-gray-950'
       >

--- a/apps/presentation/components/layout/user-menu-wrapper.tsx
+++ b/apps/presentation/components/layout/user-menu-wrapper.tsx
@@ -27,7 +27,7 @@ export function UserMenuWrapper({ className }: UserMenuWrapperProps) {
       <Button
         variant='tertiary'
         scheme='black'
-        size='none'
+        size='auto'
         className='h-6 min-w-6'
         aria-label={t('storeLocator')}
       >
@@ -40,7 +40,7 @@ export function UserMenuWrapper({ className }: UserMenuWrapperProps) {
         variant='tertiary'
         scheme='black'
         className='relative h-6 min-w-6'
-        size='none'
+        size='auto'
         asChild
       >
         <Link href={accountHref}>
@@ -56,7 +56,7 @@ export function UserMenuWrapper({ className }: UserMenuWrapperProps) {
         variant='tertiary'
         scheme='black'
         className='relative h-6 min-w-6'
-        size='none'
+        size='auto'
         asChild
       >
         <Link href='/wishlist'>
@@ -72,7 +72,7 @@ export function UserMenuWrapper({ className }: UserMenuWrapperProps) {
         variant='tertiary'
         scheme='black'
         className='relative h-6 min-w-6'
-        size='none'
+        size='auto'
         asChild
       >
         <Link href='/cart'>

--- a/apps/presentation/components/layout/user-menu-wrapper.tsx
+++ b/apps/presentation/components/layout/user-menu-wrapper.tsx
@@ -27,7 +27,9 @@ export function UserMenuWrapper({ className }: UserMenuWrapperProps) {
       <Button
         variant='tertiary'
         scheme='black'
+        size='none'
         className='h-6 min-w-6'
+        aria-label={t('storeLocator')}
       >
         <PinIcon className='size-6' />
         <span className='sr-only'>{t('storeLocator')}</span>
@@ -38,6 +40,7 @@ export function UserMenuWrapper({ className }: UserMenuWrapperProps) {
         variant='tertiary'
         scheme='black'
         className='relative h-6 min-w-6'
+        size='none'
         asChild
       >
         <Link href={accountHref}>
@@ -53,6 +56,7 @@ export function UserMenuWrapper({ className }: UserMenuWrapperProps) {
         variant='tertiary'
         scheme='black'
         className='relative h-6 min-w-6'
+        size='none'
         asChild
       >
         <Link href='/wishlist'>
@@ -68,6 +72,7 @@ export function UserMenuWrapper({ className }: UserMenuWrapperProps) {
         variant='tertiary'
         scheme='black'
         className='relative h-6 min-w-6'
+        size='none'
         asChild
       >
         <Link href='/cart'>

--- a/apps/presentation/components/ui/__tests__/button.test.tsx
+++ b/apps/presentation/components/ui/__tests__/button.test.tsx
@@ -138,7 +138,7 @@ describe('Button', () => {
       ['icon-sm', 'size-8'],
       ['icon', 'size-12'],
       ['icon-lg', 'size-14'],
-      ['none', 'gap-1.5'],
+      ['auto', 'gap-1.5'],
     ] as const)(
       'applies correct classes for size "%s"',
       (size, expectedClass) => {

--- a/apps/presentation/components/ui/__tests__/button.test.tsx
+++ b/apps/presentation/components/ui/__tests__/button.test.tsx
@@ -116,6 +116,52 @@ describe('Button', () => {
     })
   })
 
+  describe('variant prop', () => {
+    it.each([
+      ['primary', 'text-white'],
+      ['secondary', 'border-2'],
+      ['tertiary', 'bg-transparent'],
+    ] as const)(
+      'applies correct classes for variant "%s"',
+      (variant, expectedClass) => {
+        render(<Button variant={variant}>Button</Button>)
+        expect(screen.getByRole('button')).toHaveClass(expectedClass)
+      }
+    )
+  })
+
+  describe('size prop', () => {
+    it.each([
+      ['sm', 'h-8'],
+      ['default', 'h-12'],
+      ['lg', 'h-14'],
+      ['icon-sm', 'size-8'],
+      ['icon', 'size-12'],
+      ['icon-lg', 'size-14'],
+      ['none', 'gap-1.5'],
+    ] as const)(
+      'applies correct classes for size "%s"',
+      (size, expectedClass) => {
+        render(<Button size={size}>Button</Button>)
+        expect(screen.getByRole('button')).toHaveClass(expectedClass)
+      }
+    )
+  })
+
+  describe('scheme prop', () => {
+    it.each([
+      ['red', 'bg-rose-700'],
+      ['white', 'bg-white'],
+      ['black', 'bg-gray-950'],
+    ] as const)(
+      'applies correct classes for scheme "%s"',
+      (scheme, expectedClass) => {
+        render(<Button scheme={scheme}>Button</Button>)
+        expect(screen.getByRole('button')).toHaveClass(expectedClass)
+      }
+    )
+  })
+
   describe('Edge cases', () => {
     it('handles complex nested content', () => {
       render(

--- a/apps/presentation/components/ui/__tests__/product-gallery.test.tsx
+++ b/apps/presentation/components/ui/__tests__/product-gallery.test.tsx
@@ -81,7 +81,7 @@ describe('ProductGallery', () => {
     // lightbox dialog should open
     expect(screen.getByRole('dialog')).toBeInTheDocument()
     // close by clicking close button in GalleryDialog
-    await user.click(screen.getByRole('button', { name: /close lightbox/i }))
+    await user.click(screen.getByRole('button', { name: /closeButtonAria/i }))
     expect(screen.queryByRole('dialog')).toBeNull()
   })
 })

--- a/apps/presentation/components/ui/__tests__/scroll-button.test.tsx
+++ b/apps/presentation/components/ui/__tests__/scroll-button.test.tsx
@@ -10,7 +10,6 @@ describe('ScrollButton', () => {
       <ScrollButton
         side='left'
         visible={true}
-        scheme='white'
         ariaLabel='Scroll left'
         onClick={onClick}
       />
@@ -30,7 +29,6 @@ describe('ScrollButton', () => {
       <ScrollButton
         side='right'
         visible={true}
-        scheme='white'
         ariaLabel='Scroll right'
         onClick={onClick}
       />
@@ -50,7 +48,6 @@ describe('ScrollButton', () => {
       <ScrollButton
         side='left'
         visible={false}
-        scheme='white'
         ariaLabel='Hidden left'
         onClick={onClick}
       />
@@ -71,7 +68,6 @@ describe('ScrollButton', () => {
       <ScrollButton
         side='right'
         visible={true}
-        scheme='white'
         ariaLabel='Click me'
         onClick={onClick}
       />

--- a/apps/presentation/components/ui/button.tsx
+++ b/apps/presentation/components/ui/button.tsx
@@ -20,7 +20,7 @@ const buttonVariants = cva(
         'icon-sm': 'size-8 p-0',
         'icon': 'size-12 p-0',
         'icon-lg': 'size-14 p-0',
-        'none': 'gap-1.5 text-sm',
+        'auto': 'gap-1.5 text-sm',
       },
       scheme: {
         red: 'bg-rose-700 hover:bg-rose-600 active:bg-rose-600',

--- a/apps/presentation/components/ui/button.tsx
+++ b/apps/presentation/components/ui/button.tsx
@@ -4,14 +4,23 @@ import { cva, type VariantProps } from 'class-variance-authority'
 import { cn } from '@/lib/utils'
 
 const buttonVariants = cva(
-  'inline-flex h-12 min-w-12 shrink-0 cursor-pointer items-center justify-center gap-2 rounded-full text-sm leading-tight font-bold transition-all duration-200 outline-none focus-visible:ring-2 focus-visible:ring-current focus-visible:ring-offset-0 disabled:pointer-events-none disabled:cursor-default [&_svg]:pointer-events-none [&_svg]:shrink-0',
+  'inline-flex shrink-0 cursor-pointer items-center justify-center rounded-full text-sm leading-tight font-bold transition-all duration-200 outline-none focus-visible:ring-2 focus-visible:ring-current focus-visible:ring-offset-0 disabled:pointer-events-none disabled:cursor-default [&_svg]:pointer-events-none [&_svg]:shrink-0',
   {
     variants: {
       variant: {
-        primary: 'px-7 text-white disabled:bg-gray-50 disabled:text-gray-300',
+        primary: 'text-white disabled:bg-gray-50 disabled:text-gray-400',
         secondary:
-          'border-2 px-7 disabled:border-gray-300 disabled:bg-transparent disabled:text-gray-300',
-        tertiary: 'bg-transparent px-0 disabled:text-gray-300',
+          'border-2 disabled:border-gray-300 disabled:bg-transparent disabled:text-gray-400',
+        tertiary: 'bg-transparent disabled:text-gray-400',
+      },
+      size: {
+        'sm': 'h-8 min-w-8 gap-1.5 px-4 text-xs',
+        'default': 'h-12 min-w-12 gap-2 px-7 text-sm',
+        'lg': 'h-14 min-w-14 gap-2 px-8 text-base',
+        'icon-sm': 'size-8 p-0',
+        'icon': 'size-12 p-0',
+        'icon-lg': 'size-14 p-0',
+        'none': 'gap-1.5 text-sm',
       },
       scheme: {
         red: 'bg-rose-700 hover:bg-rose-600 active:bg-rose-600',
@@ -30,7 +39,7 @@ const buttonVariants = cva(
         variant: 'secondary',
         scheme: 'white',
         class:
-          'border-white bg-transparent text-white hover:border-gray-100 hover:bg-transparent hover:text-gray-100 active:border-gray-100 active:text-gray-100',
+          'border-white bg-white text-gray-950 hover:border-gray-100 hover:bg-gray-100 hover:text-gray-800 active:border-gray-100 active:text-gray-800',
       },
       {
         variant: 'secondary',
@@ -69,6 +78,7 @@ const buttonVariants = cva(
     ],
     defaultVariants: {
       variant: 'primary',
+      size: 'default',
       scheme: 'red',
     },
   }
@@ -77,6 +87,7 @@ const buttonVariants = cva(
 function Button({
   className,
   variant,
+  size,
   scheme,
   asChild = false,
   ...props
@@ -88,7 +99,7 @@ function Button({
     return (
       <Slot
         data-slot='button'
-        className={cn(buttonVariants({ variant, scheme, className }))}
+        className={cn(buttonVariants({ variant, size, scheme, className }))}
         {...(props as any)}
       />
     )
@@ -97,7 +108,7 @@ function Button({
   return (
     <button
       data-slot='button'
-      className={cn(buttonVariants({ variant, scheme, className }))}
+      className={cn(buttonVariants({ variant, size, scheme, className }))}
       {...props}
     />
   )
@@ -105,6 +116,9 @@ function Button({
 
 export type ButtonVariant = NonNullable<
   VariantProps<typeof buttonVariants>['variant']
+>
+export type ButtonSize = NonNullable<
+  VariantProps<typeof buttonVariants>['size']
 >
 export type ButtonScheme = NonNullable<
   VariantProps<typeof buttonVariants>['scheme']

--- a/apps/presentation/components/ui/carousel/carousel-navigation.tsx
+++ b/apps/presentation/components/ui/carousel/carousel-navigation.tsx
@@ -5,6 +5,7 @@ import ChevronLeftIcon from '@/public/icons/chevronleft.svg'
 import ChevronRightIcon from '@/public/icons/chevronright.svg'
 import type { CarouselNavigationProps } from '@/types/carousel'
 import { cn } from '@/lib/utils'
+import { Button } from '../button'
 
 /* TODO: Adjust button positions when tiles are impleneted! */
 export function CarouselNavigation({
@@ -21,33 +22,39 @@ export function CarouselNavigation({
   return (
     <div className={className}>
       {!isAtStart && (
-        <button
+        <Button
           type='button'
+          variant='secondary'
+          scheme='white'
+          size='icon-lg'
           className={cn(
-            'absolute top-[var(--carousel-arrow-position)] z-[var(--z-carousel-arrow)] flex size-14 -translate-y-1/2 items-center justify-center rounded-full border border-gray-200 bg-white opacity-0 shadow-[0_2px_2px_0_rgba(0,0,0,0.05)] transition-colors duration-200 group-hover:opacity-100 hover:text-green-600 starting:opacity-0 touchscreen:hidden',
+            'absolute top-[var(--carousel-arrow-position)] z-[var(--z-carousel-arrow)] -translate-y-1/2 opacity-0 shadow-[0_2px_2px_0_rgba(0,0,0,0.05)] group-hover:opacity-100 starting:opacity-0 touchscreen:hidden',
             'left-(--_fullbleed) ml-6'
           )}
           aria-label={t('previousSlide')}
           aria-controls={carouselId}
           onClick={onSlideToPrev}
         >
-          <ChevronLeftIcon className='pointer-events-none size-6' />
-        </button>
+          <ChevronLeftIcon className='pointer-events-none size-8' />
+        </Button>
       )}
 
       {isNextSlidePossible && (
-        <button
+        <Button
           type='button'
+          variant='secondary'
+          scheme='white'
+          size='icon-lg'
           className={cn(
-            'absolute top-[var(--carousel-arrow-position)] z-[var(--z-carousel-arrow)] flex size-14 -translate-y-1/2 items-center justify-center rounded-full border border-gray-200 bg-white opacity-0 shadow-[0_2px_2px_0_rgba(0,0,0,0.05)] transition-colors duration-200 group-hover:opacity-100 hover:text-green-600 starting:opacity-0 touchscreen:hidden',
+            'absolute top-[var(--carousel-arrow-position)] z-[var(--z-carousel-arrow)] -translate-y-1/2 opacity-0 shadow-[0_2px_2px_0_rgba(0,0,0,0.05)] group-hover:opacity-100 starting:opacity-0 touchscreen:hidden',
             'right-(--_fullbleed) mr-6'
           )}
           aria-label={t('nextSlide')}
           aria-controls={carouselId}
           onClick={onSlideToNext}
         >
-          <ChevronRightIcon className='pointer-events-none size-6' />
-        </button>
+          <ChevronRightIcon className='pointer-events-none size-8' />
+        </Button>
       )}
     </div>
   )

--- a/apps/presentation/components/ui/gallery-dialog.tsx
+++ b/apps/presentation/components/ui/gallery-dialog.tsx
@@ -12,6 +12,7 @@ import {
   DialogTitle,
   DialogDescription,
 } from '@/components/ui/dialog'
+import { Button } from './button'
 
 export interface GalleryImage {
   src: string
@@ -112,14 +113,16 @@ export const GalleryDialog: React.FC<GalleryDialogProps> = ({
         <DialogDescription className='sr-only'>
           {t('dialogDescription')}
         </DialogDescription>
-        <button
-          type='button'
-          className='absolute top-4 right-4 z-10 rounded-full bg-white/90 p-2 shadow-sm hover:bg-white'
+        <Button
+          size='icon-sm'
+          variant='secondary'
+          scheme='white'
+          className='absolute top-4 right-4 z-10 p-2 shadow-sm'
           onClick={onClose}
-          aria-label='Close lightbox'
+          aria-label={t('closeButtonAria')}
         >
           <CloseIcon className='size-5' />
-        </button>
+        </Button>
         <div className='flex h-full w-full flex-1 [&_[data-role=carousel]]:h-full [&_[data-role=carousel]_[role=group]]:h-full [&_[data-role=carousel]_div[role=group]]:h-full [&_[data-role=carousel]>div]:h-full [&_button[type=button]]:opacity-100'>
           <Carousel
             ref={carouselRef}

--- a/apps/presentation/components/ui/horizontal-scroller.tsx
+++ b/apps/presentation/components/ui/horizontal-scroller.tsx
@@ -106,7 +106,6 @@ export function HorizontalScroller({
       <ScrollButton
         side='left'
         visible={canScrollLeft}
-        scheme={scheme}
         ariaLabel={t('scrollLeft')}
         onClick={() => scroll('left')}
       />
@@ -124,7 +123,6 @@ export function HorizontalScroller({
       <ScrollButton
         side='right'
         visible={canScrollRight}
-        scheme={scheme}
         ariaLabel={t('scrollRight')}
         onClick={() => scroll('right')}
       />

--- a/apps/presentation/components/ui/pagination.tsx
+++ b/apps/presentation/components/ui/pagination.tsx
@@ -1,9 +1,11 @@
 'use client'
 
 import { useTranslations } from 'next-intl'
-import Image from 'next/image'
+import ArrowLeftIcon from '@/public/icons/arrow-left.svg'
+import ArrowRightIcon from '@/public/icons/arrow-right.svg'
 import { cn } from '@/lib/utils'
 import { MIN_PAGE } from '@config/constants'
+import { Button } from './button'
 
 interface PaginationProps {
   currentPage: number
@@ -40,57 +42,38 @@ export function Pagination({
       role='navigation'
       aria-label={t('ariaLabel')}
     >
-      <button
+      <Button
+        size='icon'
         onClick={() => goToPage(currentPage - 1)}
         disabled={!canGoPrevious}
-        className={cn(
-          'flex h-[50px] w-[50px] items-center justify-center rounded-full transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-primary)]',
-          canGoPrevious
-            ? 'cursor-pointer bg-[var(--color-primary)] hover:opacity-90'
-            : 'cursor-not-allowed bg-[var(--color-gray-100)]'
-        )}
         aria-label={t('previousPage')}
       >
-        <Image
-          src='/icons/arrow-left.svg'
-          alt=''
-          width={24}
-          height={24}
+        <ArrowLeftIcon
           aria-hidden='true'
-          className={
-            canGoPrevious ? 'brightness-0 invert' : 'opacity-40 grayscale'
-          }
+          className='size-6'
         />
-      </button>
+      </Button>
 
       <span
         className='text-base font-medium'
+        aria-current='page'
         aria-live='polite'
         aria-atomic='true'
       >
         {t('pageOf', { currentPage, totalPages })}
       </span>
 
-      <button
+      <Button
+        size='icon'
         onClick={() => goToPage(currentPage + 1)}
         disabled={!canGoNext}
-        className={cn(
-          'flex h-[50px] w-[50px] items-center justify-center rounded-full transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-primary)]',
-          canGoNext
-            ? 'cursor-pointer bg-[var(--color-primary)] hover:opacity-90'
-            : 'cursor-not-allowed bg-[var(--color-gray-100)]'
-        )}
         aria-label={t('nextPage')}
       >
-        <Image
-          src='/icons/arrow-right.svg'
-          alt=''
-          width={24}
-          height={24}
+        <ArrowRightIcon
           aria-hidden='true'
-          className={canGoNext ? 'brightness-0 invert' : 'opacity-40 grayscale'}
+          className={cn('size-6', canGoNext ? 'text-white' : 'text-gray-400')}
         />
-      </button>
+      </Button>
     </nav>
   )
 }

--- a/apps/presentation/components/ui/scroll-button.tsx
+++ b/apps/presentation/components/ui/scroll-button.tsx
@@ -1,13 +1,12 @@
 'use client'
 
 import { cn } from '@/lib/utils'
-
+import { Button } from './button'
 import ChevronRightIcon from '@/public/icons/chevronright.svg'
 
 export interface ScrollButtonProps {
   side: 'left' | 'right'
   visible: boolean
-  scheme?: 'white' | 'dark'
   onClick: () => void
   ariaLabel: string
   className?: string
@@ -16,20 +15,20 @@ export interface ScrollButtonProps {
 export function ScrollButton({
   side,
   visible,
-  scheme = 'white',
   onClick,
   ariaLabel,
   className,
 }: ScrollButtonProps) {
   return (
-    <button
+    <Button
+      size='icon-sm'
+      variant='secondary'
+      scheme='white'
       className={cn(
-        'absolute top-1/2 z-[var(--z-scroll-button)] -mt-0.5 flex size-8 -translate-y-1/2 cursor-pointer items-center justify-center rounded-full border border-gray-200 bg-white shadow-sm transition focus-visible:ring-2 focus-visible:outline-none [&:focus-visible>svg]:fill-primary pointer-fine:[&:hover>svg]:fill-primary',
+        'absolute top-1/2 z-[var(--z-scroll-button)] -mt-0.5 -translate-y-1/2 shadow-sm [&:focus-visible>svg]:fill-primary pointer-fine:[&:hover>svg]:fill-primary',
         {
           'left-0': side === 'left',
           'right-0': side === 'right',
-          'focus-visible:ring-gray-200/50': scheme === 'white',
-          'focus-visible:ring-gray-950/50': scheme === 'dark',
           'opacity-100': visible,
           'pointer-events-none opacity-0': !visible,
         },
@@ -42,10 +41,10 @@ export function ScrollButton({
       onClick={onClick}
     >
       <ChevronRightIcon
-        className={cn('pointer-events-none size-6 shrink-0 transition-colors', {
+        className={cn('size-6 transition-colors', {
           '-scale-100': side === 'left',
         })}
       />
-    </button>
+    </Button>
   )
 }

--- a/apps/presentation/components/ui/toast.tsx
+++ b/apps/presentation/components/ui/toast.tsx
@@ -141,6 +141,7 @@ function Toast({
         <Button
           variant='tertiary'
           scheme='black'
+          size='icon-sm'
           className='focus-visible:ring-current/20'
           aria-label={t('close')}
           onClick={() => sonnerToast.dismiss(id)}

--- a/apps/presentation/features/account/account-navigation.tsx
+++ b/apps/presentation/features/account/account-navigation.tsx
@@ -68,12 +68,17 @@ export const AccountNavigation: FC<AccountNavigationProps> = ({
             <Button
               variant='tertiary'
               scheme='black'
+              size='none'
+              className='h-12'
+              asChild
             >
-              <ChevronLeftIcon
-                className='size-6'
-                aria-hidden='true'
-              />
-              <Link href='/account'>{t('backButtonLabel')}</Link>
+              <Link href='/account'>
+                <ChevronLeftIcon
+                  className='size-6'
+                  aria-hidden='true'
+                />
+                {t('backButtonLabel')}
+              </Link>
             </Button>
           </li>
         </ul>

--- a/apps/presentation/features/account/account-navigation.tsx
+++ b/apps/presentation/features/account/account-navigation.tsx
@@ -68,7 +68,7 @@ export const AccountNavigation: FC<AccountNavigationProps> = ({
             <Button
               variant='tertiary'
               scheme='black'
-              size='none'
+              size='auto'
               className='h-12'
               asChild
             >

--- a/apps/presentation/features/address/address-form.tsx
+++ b/apps/presentation/features/address/address-form.tsx
@@ -216,7 +216,7 @@ export function AddressForm({
         <Button
           type='button'
           scheme='black'
-          size='none'
+          size='auto'
           variant='tertiary'
           onClick={() => setShowAdditionalStreetInfo(true)}
         >

--- a/apps/presentation/features/address/address-form.tsx
+++ b/apps/presentation/features/address/address-form.tsx
@@ -17,6 +17,7 @@ import {
 } from '@core/contracts/address/address-base'
 import PlusIcon from '@/public/icons/plus.svg'
 import { Checkbox } from '@/components/ui/checkbox'
+import { Button } from '@/components/ui/button'
 
 export interface AddressFormState {
   isDirty: boolean
@@ -212,14 +213,16 @@ export function AddressForm({
 
       {/* Additional Street Info - Expandable */}
       {!showAdditionalStreetInfo ? (
-        <button
+        <Button
           type='button'
+          scheme='black'
+          size='none'
+          variant='tertiary'
           onClick={() => setShowAdditionalStreetInfo(true)}
-          className='flex items-center gap-2 text-sm text-gray-700 hover:text-gray-900'
         >
           <PlusIcon className='size-4' />
           {t('additionalAddressLine')}
-        </button>
+        </Button>
       ) : (
         <Field>
           <Controller

--- a/apps/presentation/features/auth/auth-login-form.tsx
+++ b/apps/presentation/features/auth/auth-login-form.tsx
@@ -112,6 +112,7 @@ export function LoginForm({ onSuccess }: LoginFormProps) {
                 <Button
                   type='button'
                   variant='tertiary'
+                  size='none'
                   className='h-auto justify-start p-0 text-sm underline'
                   disabled={resendVerificationEmailMutation.isPending}
                   onClick={onResendVerificationEmail}
@@ -196,6 +197,7 @@ export function LoginForm({ onSuccess }: LoginFormProps) {
         <Button
           type='submit'
           disabled={form.formState.isSubmitting || loginMutation.isPending}
+          aria-busy={form.formState.isSubmitting || loginMutation.isPending}
           className='w-full uppercase'
         >
           {form.formState.isSubmitting || loginMutation.isPending

--- a/apps/presentation/features/auth/auth-login-form.tsx
+++ b/apps/presentation/features/auth/auth-login-form.tsx
@@ -112,7 +112,7 @@ export function LoginForm({ onSuccess }: LoginFormProps) {
                 <Button
                   type='button'
                   variant='tertiary'
-                  size='none'
+                  size='auto'
                   className='h-auto justify-start p-0 text-sm underline'
                   disabled={resendVerificationEmailMutation.isPending}
                   onClick={onResendVerificationEmail}

--- a/apps/presentation/features/auth/auth-logout-button.tsx
+++ b/apps/presentation/features/auth/auth-logout-button.tsx
@@ -25,7 +25,7 @@ export const LogoutButton: FC<LogoutButtonProps> = ({
       type='button'
       variant='tertiary'
       scheme='black'
-      size='none'
+      size='auto'
       onClick={async () => {
         await handleLogout()
       }}

--- a/apps/presentation/features/auth/auth-logout-button.tsx
+++ b/apps/presentation/features/auth/auth-logout-button.tsx
@@ -5,6 +5,7 @@ import { useTranslations } from 'next-intl'
 import { FC } from 'react'
 import LogoutIcon from '@/public/icons/logout.svg'
 import { cn } from '@/lib/utils'
+import { Button } from '@/components/ui/button'
 
 interface LogoutButtonProps {
   className?: string
@@ -20,15 +21,18 @@ export const LogoutButton: FC<LogoutButtonProps> = ({
   const { handleLogout, isLoggingOut } = useLogout({ onSuccess: onAfterLogout })
 
   return (
-    <button
+    <Button
       type='button'
+      variant='tertiary'
+      scheme='black'
+      size='none'
       onClick={async () => {
         await handleLogout()
       }}
       disabled={isLoggingOut}
       aria-busy={isLoggingOut}
       className={cn(
-        'flex cursor-pointer gap-3 disabled:cursor-not-allowed',
+        'flex justify-start gap-3 disabled:cursor-not-allowed',
         className
       )}
     >
@@ -37,6 +41,6 @@ export const LogoutButton: FC<LogoutButtonProps> = ({
         aria-hidden='true'
       />
       <span>{t('logout')}</span>
-    </button>
+    </Button>
   )
 }

--- a/apps/presentation/features/cart/components/add-to-cart-modal.tsx
+++ b/apps/presentation/features/cart/components/add-to-cart-modal.tsx
@@ -15,6 +15,7 @@ import { CartSummary } from './cart-summary'
 import { CartActions } from './cart-actions'
 import { ShowMoreProducts } from './show-more-products'
 import CloseIcon from '@/public/icons/close.svg'
+import { Button } from '@/components/ui/button'
 
 interface AddToCartModalProps {
   open: boolean
@@ -58,13 +59,15 @@ export function AddToCartModal({ open, onOpenChange }: AddToCartModalProps) {
               {`${t('title')} (${cart.itemCount})`}
             </p>
           </DialogTitle>
-          <button
+          <Button
+            size='icon-sm'
+            scheme='black'
+            variant='tertiary'
             onClick={() => onOpenChange(false)}
-            className='relative flex h-6 w-6 shrink-0 cursor-pointer items-center justify-center'
             aria-label={tCommon('close')}
           >
             <CloseIcon className='h-6 w-6 shrink-0 text-gray-700' />
-          </button>
+          </Button>
         </DialogHeader>
 
         {/* Scrollable Content Area - positioned at left-6 top-14 with width 409px */}

--- a/apps/presentation/features/cart/components/cart-item-removal-confirmation.tsx
+++ b/apps/presentation/features/cart/components/cart-item-removal-confirmation.tsx
@@ -3,6 +3,7 @@
 import { useRef, useEffect } from 'react'
 import { useTranslations } from 'next-intl'
 import type { LineItemResponse } from '@core/contracts/cart/cart'
+import { Button } from '@/components/ui/button'
 
 interface CartItemRemovalConfirmationProps {
   item: LineItemResponse
@@ -47,27 +48,28 @@ export function CartItemRemovalConfirmation({
         {t('item.removeConfirmation.message', { name: item.name })}
       </p>
       <div className='flex gap-3'>
-        <button
+        <Button
+          variant='secondary'
           onClick={onCancel}
           disabled={isRemoving}
-          className='flex items-center justify-center rounded border border-black bg-white px-6 py-2 text-sm/[1.6] font-normal text-black transition-opacity hover:opacity-90 focus:ring-2 focus:ring-black focus:ring-offset-2 focus:ring-offset-white focus:outline-none disabled:cursor-not-allowed disabled:opacity-50'
           aria-label={t('item.removeConfirmation.cancel')}
+          aria-busy={isRemoving}
         >
           <span>{t('item.removeConfirmation.cancel')}</span>
-        </button>
-        <button
+        </Button>
+        <Button
           ref={confirmButtonRef}
           onClick={onConfirm}
           disabled={isRemoving}
-          className='flex items-center justify-center rounded border border-black bg-white px-6 py-2 text-sm/[1.6] font-normal text-black transition-opacity hover:opacity-90 focus:ring-2 focus:ring-black focus:ring-offset-2 focus:ring-offset-white focus:outline-none disabled:cursor-not-allowed disabled:opacity-50'
           aria-label={t('item.removeConfirmation.confirm')}
+          aria-busy={isRemoving}
         >
           <span>
             {isRemoving
               ? t('item.removeConfirmation.removing')
               : t('item.removeConfirmation.confirm')}
           </span>
-        </button>
+        </Button>
       </div>
       <p
         id='removal-confirmation-description'

--- a/apps/presentation/features/cart/components/cart-item/cart-item-actions.tsx
+++ b/apps/presentation/features/cart/components/cart-item/cart-item-actions.tsx
@@ -28,7 +28,7 @@ export function CartItemActions({
   const buttons = (
     <>
       <Button
-        size={showText ? 'none' : 'icon-sm'}
+        size={showText ? 'auto' : 'icon-sm'}
         scheme='black'
         variant='tertiary'
         onClick={() => onRemoveClick?.()}

--- a/apps/presentation/features/cart/components/cart-item/cart-item-actions.tsx
+++ b/apps/presentation/features/cart/components/cart-item/cart-item-actions.tsx
@@ -4,6 +4,7 @@ import TrashBinIcon from '@/public/icons/trash-bin.svg'
 import { useTranslations } from 'next-intl'
 import { cn } from '@/lib/utils'
 import { WishlistToggleButton } from '@/features/wishlist/wishlist-toggle-button'
+import { Button } from '@/components/ui/button'
 
 interface CartItemActionsProps {
   variant?: 'icon-only' | 'with-text'
@@ -26,12 +27,13 @@ export function CartItemActions({
 
   const buttons = (
     <>
-      <button
-        type='button'
+      <Button
+        size={showText ? 'none' : 'icon-sm'}
+        scheme='black'
+        variant='tertiary'
         onClick={() => onRemoveClick?.()}
         disabled={isRemoving}
         className={cn(
-          'flex cursor-pointer items-center',
           {
             'shrink-0 gap-2': showText,
             'justify-center': !showText,
@@ -40,7 +42,7 @@ export function CartItemActions({
         )}
         aria-label={removeLabel}
       >
-        <TrashBinIcon className='h-6 w-6 shrink-0 text-gray-700' />
+        <TrashBinIcon className='size-6 shrink-0 text-gray-700' />
         {showText && (
           <span
             className={cn(
@@ -51,7 +53,7 @@ export function CartItemActions({
             {removeLabel}
           </span>
         )}
-      </button>
+      </Button>
       {!showText && <div className='h-8 w-px bg-gray-300' />}
       <WishlistToggleButton
         productId={productId}

--- a/apps/presentation/features/cart/components/show-more-products.tsx
+++ b/apps/presentation/features/cart/components/show-more-products.tsx
@@ -3,6 +3,7 @@
 import * as React from 'react'
 import { useTranslations } from 'next-intl'
 import ChevronDownIcon from '@/public/icons/chevron-down.svg'
+import { Button } from '@/components/ui/button'
 
 interface ShowMoreProductsProps {
   scrollRef: React.RefObject<HTMLDivElement | null>
@@ -76,9 +77,12 @@ export function ShowMoreProducts({
 
   return (
     <div className='flex w-full shrink-0 flex-col items-start gap-2.5 p-2'>
-      <div className='flex w-full shrink-0 flex-col items-center gap-2 rounded-lg bg-gray-50 px-0 py-3'>
-        <button
+      <div className='flex w-full shrink-0 flex-col items-center'>
+        <Button
           type='button'
+          size='default'
+          scheme='black'
+          variant='tertiary'
           onClick={() => {
             setShowMoreProducts(!showMoreProducts)
             if (scrollRef.current) {
@@ -88,14 +92,12 @@ export function ShowMoreProducts({
               })
             }
           }}
-          className='flex cursor-pointer items-center gap-2 p-0'
+          // className='flex cursor-pointer items-center gap-2 p-0'
           aria-expanded={showMoreProducts}
         >
-          <span className='text-sm/[1.6] font-normal whitespace-pre text-gray-700 underline decoration-solid'>
-            {t('addToCartModal.moreProducts')}
-          </span>
+          {t('addToCartModal.moreProducts')}
           <ChevronDownIcon className='h-6 w-6 shrink-0 text-gray-700' />
-        </button>
+        </Button>
       </div>
     </div>
   )

--- a/apps/presentation/features/cart/components/variant-selector-modal.tsx
+++ b/apps/presentation/features/cart/components/variant-selector-modal.tsx
@@ -113,17 +113,19 @@ export function VariantSelectorModal({
       >
         {/* Header */}
         <DialogHeader className='relative flex h-14 w-full items-center justify-between bg-white !px-4 py-4 md:w-112'>
-          <div className='relative h-6 w-6 shrink-0 opacity-0' />
+          <div className='relative size-8 shrink-0 opacity-0' />
           <DialogTitle className='relative flex shrink-0 flex-col justify-center text-center text-base leading-none font-normal text-nowrap text-gray-950'>
             <p className='leading-[1.1] whitespace-pre'>{productName}</p>
           </DialogTitle>
-          <button
+          <Button
+            variant='tertiary'
+            scheme='black'
+            size='icon-sm'
             onClick={() => onOpenChange(false)}
-            className='relative flex h-6 w-6 shrink-0 cursor-pointer items-center justify-center'
             aria-label={tCommon('close')}
           >
             <CloseIcon className='h-6 w-6 shrink-0 text-gray-700' />
-          </button>
+          </Button>
         </DialogHeader>
 
         {/* Content */}
@@ -159,6 +161,7 @@ export function VariantSelectorModal({
             onClick={handleAddToBasket}
             disabled={isAddDisabled}
             className='w-full'
+            aria-busy={isAdding}
           >
             {isAdding ? (
               <>

--- a/apps/presentation/features/checkout/components/address-step/address-step-book.tsx
+++ b/apps/presentation/features/checkout/components/address-step/address-step-book.tsx
@@ -103,8 +103,10 @@ export function AddressStepBook({
         </RadioGroup>
 
         {hasMore && (
-          <button
-            type='button'
+          <Button
+            scheme='black'
+            variant='tertiary'
+            size='none'
             onClick={toggleShowAll}
             className='mt-4 flex items-center gap-2 text-sm text-gray-700 underline hover:text-gray-900'
           >
@@ -119,7 +121,7 @@ export function AddressStepBook({
                 {t('addresses.showMore')}
               </>
             )}
-          </button>
+          </Button>
         )}
       </Card>
 

--- a/apps/presentation/features/checkout/components/address-step/address-step-book.tsx
+++ b/apps/presentation/features/checkout/components/address-step/address-step-book.tsx
@@ -106,7 +106,7 @@ export function AddressStepBook({
           <Button
             scheme='black'
             variant='tertiary'
-            size='none'
+            size='auto'
             onClick={toggleShowAll}
             className='mt-4 flex items-center gap-2 text-sm text-gray-700 underline hover:text-gray-900'
           >

--- a/apps/presentation/features/checkout/components/address-step/address-step-manage-addresses-modal.tsx
+++ b/apps/presentation/features/checkout/components/address-step/address-step-manage-addresses-modal.tsx
@@ -131,6 +131,7 @@ export function AddressStepManageAddressesModal({
             <Button
               variant='tertiary'
               scheme='black'
+              size='none'
               onClick={() => setFormMode(undefined)}
               className='flex items-center gap-2'
             >

--- a/apps/presentation/features/checkout/components/address-step/address-step-manage-addresses-modal.tsx
+++ b/apps/presentation/features/checkout/components/address-step/address-step-manage-addresses-modal.tsx
@@ -131,7 +131,7 @@ export function AddressStepManageAddressesModal({
             <Button
               variant='tertiary'
               scheme='black'
-              size='none'
+              size='auto'
               onClick={() => setFormMode(undefined)}
               className='flex items-center gap-2'
             >

--- a/apps/presentation/features/customer/components/customer-address-removal-confirmation.tsx
+++ b/apps/presentation/features/customer/components/customer-address-removal-confirmation.tsx
@@ -3,6 +3,7 @@
 import { useRef, useEffect, FC } from 'react'
 import { useTranslations } from 'next-intl'
 import type { AddressResponse } from '@core/contracts/customer/address'
+import { Button } from '@/components/ui/button'
 
 interface CustomerAddressRemovalConfirmationProps {
   address: AddressResponse
@@ -49,25 +50,24 @@ export const CustomerAddressRemovalConfirmation: FC<
         {t('addresses.deleteConfirmation', { addressLabel })}
       </p>
       <div className='flex gap-3'>
-        <button
+        <Button
+          variant='secondary'
           onClick={onCancel}
           disabled={isDeleting}
-          className='flex items-center justify-center rounded border border-black bg-white px-6 py-2 text-sm/[1.6] font-normal text-black transition-opacity hover:opacity-90 focus:ring-2 focus:ring-black focus:ring-offset-2 focus:ring-offset-white focus:outline-none disabled:cursor-not-allowed disabled:opacity-50'
           aria-label={t('cancel')}
         >
           <span>{t('cancel')}</span>
-        </button>
-        <button
+        </Button>
+        <Button
           ref={confirmButtonRef}
           onClick={onConfirm}
           disabled={isDeleting}
-          className='flex items-center justify-center rounded border border-black bg-white px-6 py-2 text-sm/[1.6] font-normal text-black transition-opacity hover:opacity-90 focus:ring-2 focus:ring-black focus:ring-offset-2 focus:ring-offset-white focus:outline-none disabled:cursor-not-allowed disabled:opacity-50'
           aria-label={t('addresses.delete')}
         >
           <span>
             {isDeleting ? t('addresses.deleting') : t('addresses.delete')}
           </span>
-        </button>
+        </Button>
       </div>
       <p
         id='removal-confirmation-description'

--- a/apps/presentation/features/customer/customer-address-item.tsx
+++ b/apps/presentation/features/customer/customer-address-item.tsx
@@ -98,7 +98,7 @@ export const CustomerAddressItem: FC<CustomerAddressItemProps> = ({
           <Button
             variant='primary'
             scheme='black'
-            className='h-auto py-2'
+            size='sm'
             onClick={() => onEdit(address)}
             aria-label={t('addresses.edit')}
           >
@@ -108,7 +108,7 @@ export const CustomerAddressItem: FC<CustomerAddressItemProps> = ({
           <Button
             variant='secondary'
             scheme='black'
-            className='h-auto py-2'
+            size='sm'
             onClick={handleDeleteClick}
             aria-label={t('addresses.delete')}
             disabled={isDeleteAddressPending || showDeleteConfirmation}
@@ -126,6 +126,7 @@ export const CustomerAddressItem: FC<CustomerAddressItemProps> = ({
           <Button
             variant='tertiary'
             scheme='black'
+            size='none'
             className='h-auto py-1 text-xs'
             onClick={onSetDefaultShipping}
             disabled={isSetDefaultShippingPending}
@@ -141,6 +142,7 @@ export const CustomerAddressItem: FC<CustomerAddressItemProps> = ({
           <Button
             variant='tertiary'
             scheme='black'
+            size='none'
             className='h-auto py-1 text-xs'
             onClick={onSetDefaultBilling}
             disabled={isSetDefaultBillingPending}

--- a/apps/presentation/features/customer/customer-address-item.tsx
+++ b/apps/presentation/features/customer/customer-address-item.tsx
@@ -126,7 +126,7 @@ export const CustomerAddressItem: FC<CustomerAddressItemProps> = ({
           <Button
             variant='tertiary'
             scheme='black'
-            size='none'
+            size='auto'
             className='h-auto py-1 text-xs'
             onClick={onSetDefaultShipping}
             disabled={isSetDefaultShippingPending}
@@ -142,7 +142,7 @@ export const CustomerAddressItem: FC<CustomerAddressItemProps> = ({
           <Button
             variant='tertiary'
             scheme='black'
-            size='none'
+            size='auto'
             className='h-auto py-1 text-xs'
             onClick={onSetDefaultBilling}
             disabled={isSetDefaultBillingPending}

--- a/apps/presentation/features/customer/customer-data.tsx
+++ b/apps/presentation/features/customer/customer-data.tsx
@@ -92,6 +92,7 @@ export const CustomerData: FC = () => {
           <Button
             variant='primary'
             scheme='black'
+            size='sm'
             className='h-auto py-2'
             aria-label={t('customerData.edit')}
             onClick={() => setOpen(true)}

--- a/apps/presentation/features/navigation/components/mobile-menu-button.tsx
+++ b/apps/presentation/features/navigation/components/mobile-menu-button.tsx
@@ -1,28 +1,34 @@
 'use client'
 
 import { useState } from 'react'
+import { useTranslations } from 'next-intl'
 import { MainNavigationResponse } from '@core/contracts/navigation/main-navigation'
 import HamburgerMenuIcon from '@/public/icons/hamburgermenu.svg'
 import { MobileNavigation } from './mobile-navigation/mobile-navigation'
+import { Button } from '@/components/ui/button'
 
 interface MobileMenuButtonProps {
   navigationItems: MainNavigationResponse | null
 }
 
 export function MobileMenuButton({ navigationItems }: MobileMenuButtonProps) {
+  const t = useTranslations('common')
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false)
 
   return (
     <>
-      <button
-        type='button'
-        className='inline-flex size-8 items-center justify-center lord-of-the-focus-ring rounded-md text-sm font-medium transition-colors hover:bg-gray-100 hover:text-primary disabled:pointer-events-none disabled:opacity-50'
+      <Button
+        size='icon-sm'
+        variant='tertiary'
+        scheme='black'
+        className='inline-flex items-center justify-center lord-of-the-focus-ring rounded-md text-sm font-medium transition-colors hover:bg-gray-100 hover:text-primary disabled:pointer-events-none disabled:opacity-50'
         onClick={() => setIsMobileMenuOpen(true)}
         aria-expanded={isMobileMenuOpen}
-        aria-label='Toggle mobile menu'
+        aria-label={t('toggleMobileMenu')}
+        aria-haspopup='menu'
       >
         <HamburgerMenuIcon className='size-5' />
-      </button>
+      </Button>
 
       <MobileNavigation
         open={isMobileMenuOpen}

--- a/apps/presentation/features/navigation/components/mobile-navigation/mobile-navigation.tsx
+++ b/apps/presentation/features/navigation/components/mobile-navigation/mobile-navigation.tsx
@@ -18,6 +18,7 @@ import { Logo } from '@/components/ui/logo'
 import { NavigationList } from './navigation-list'
 import { NavigationAccordion } from './navigation-accordion'
 import { useNavigationState } from '../../hooks/use-navigation-state'
+import { Button } from '@/components/ui/button'
 
 interface MobileNavigationProps {
   open: boolean
@@ -88,7 +89,10 @@ export function MobileNavigation({
         <div className='relative flex h-14 shrink-0 items-center justify-center px-4 shadow-down'>
           {/* Back button - show on level 2 and 3 */}
           {currentLevel > 1 && (
-            <button
+            <Button
+              variant='tertiary'
+              scheme='black'
+              size='none'
               onClick={goBackOneLevel}
               className='absolute left-4 flex size-6 shrink-0 items-center justify-center lord-of-the-focus-ring rounded'
               aria-label='Go back'
@@ -97,7 +101,7 @@ export function MobileNavigation({
                 className='size-6 rotate-180'
                 aria-hidden='true'
               />
-            </button>
+            </Button>
           )}
 
           {currentLevel === 1 ? (
@@ -120,16 +124,19 @@ export function MobileNavigation({
           )}
 
           {/* Close button */}
-          <button
+          <Button
+            variant='tertiary'
+            scheme='black'
+            size='none'
             onClick={closeMobileNavigation}
-            className='absolute right-4 flex size-6 shrink-0 cursor-pointer items-center justify-center lord-of-the-focus-ring rounded'
+            className='absolute right-4 flex size-6 shrink-0 items-center justify-center lord-of-the-focus-ring rounded'
             aria-label={t('close')}
           >
             <CloseIcon
               className='size-6'
               aria-hidden='true'
             />
-          </button>
+          </Button>
         </div>
 
         <SheetBody className='relative flex-row overflow-hidden p-0'>

--- a/apps/presentation/features/navigation/components/mobile-navigation/mobile-navigation.tsx
+++ b/apps/presentation/features/navigation/components/mobile-navigation/mobile-navigation.tsx
@@ -92,7 +92,7 @@ export function MobileNavigation({
             <Button
               variant='tertiary'
               scheme='black'
-              size='none'
+              size='auto'
               onClick={goBackOneLevel}
               className='absolute left-4 flex size-6 shrink-0 items-center justify-center lord-of-the-focus-ring rounded'
               aria-label='Go back'
@@ -127,7 +127,7 @@ export function MobileNavigation({
           <Button
             variant='tertiary'
             scheme='black'
-            size='none'
+            size='auto'
             onClick={closeMobileNavigation}
             className='absolute right-4 flex size-6 shrink-0 items-center justify-center lord-of-the-focus-ring rounded'
             aria-label={t('close')}

--- a/apps/presentation/features/order-history/components/order-history-item.tsx
+++ b/apps/presentation/features/order-history/components/order-history-item.tsx
@@ -61,6 +61,7 @@ export const OrderHistoryItem: FC<OrderHistoryItemProps> = ({ order }) => {
       <Button
         variant='tertiary'
         scheme='black'
+        size='none'
         className='h-auto w-auto lg:order-6 lg:col-span-5 lg:justify-self-end xl:col-span-1'
         asChild
       >

--- a/apps/presentation/features/order-history/components/order-history-item.tsx
+++ b/apps/presentation/features/order-history/components/order-history-item.tsx
@@ -61,7 +61,7 @@ export const OrderHistoryItem: FC<OrderHistoryItemProps> = ({ order }) => {
       <Button
         variant='tertiary'
         scheme='black'
-        size='none'
+        size='auto'
         className='h-auto w-auto lg:order-6 lg:col-span-5 lg:justify-self-end xl:col-span-1'
         asChild
       >

--- a/apps/presentation/features/order-history/order-history-detail.tsx
+++ b/apps/presentation/features/order-history/order-history-detail.tsx
@@ -66,7 +66,7 @@ export const OrderHistoryDetail: FC<OrderHistoryDetailProps> = ({
           <Button
             variant='tertiary'
             scheme='black'
-            size='none'
+            size='auto'
             className='h-12'
             aria-label={t('backToOrders')}
             asChild

--- a/apps/presentation/features/order-history/order-history-detail.tsx
+++ b/apps/presentation/features/order-history/order-history-detail.tsx
@@ -66,6 +66,9 @@ export const OrderHistoryDetail: FC<OrderHistoryDetailProps> = ({
           <Button
             variant='tertiary'
             scheme='black'
+            size='none'
+            className='h-12'
+            aria-label={t('backToOrders')}
             asChild
           >
             <Link

--- a/apps/presentation/features/order-history/order-history-list.tsx
+++ b/apps/presentation/features/order-history/order-history-list.tsx
@@ -108,9 +108,9 @@ export const OrderHistoryList: FC = () => {
             <Button
               variant='secondary'
               scheme='black'
+              size='sm'
               onClick={() => navigateToPage(currentPage - 1)}
               disabled={!hasPrevious}
-              className='h-9 min-w-9 gap-1 px-3 text-sm'
             >
               <ChevronLeftIcon className='h-4 w-4' />
               {t('previous')}
@@ -121,9 +121,9 @@ export const OrderHistoryList: FC = () => {
             <Button
               variant='secondary'
               scheme='black'
+              size='sm'
               onClick={() => navigateToPage(currentPage + 1)}
               disabled={!hasNext}
-              className='h-9 min-w-9 gap-1 px-3 text-sm'
             >
               {t('next')}
               <ChevronRightIcon className='h-4 w-4' />

--- a/apps/presentation/features/productCollection/components/active-filters.tsx
+++ b/apps/presentation/features/productCollection/components/active-filters.tsx
@@ -118,6 +118,7 @@ export function ActiveFilters({
             key={chip.id}
             type='button'
             onClick={() => handleRemoveChip(chip)}
+            aria-label={t('filters.removeChipAria', { name: chip.label })}
             className='flex shrink-0 cursor-pointer items-center gap-1 rounded-full bg-gray-100 px-3 py-0.5 text-sm'
           >
             {chip.label}
@@ -133,8 +134,9 @@ export function ActiveFilters({
         className='shrink-0 cursor-pointer text-sm underline'
         type='button'
         onClick={handleClearAll}
+        aria-label={t('filters.clearAll')}
       >
-        {t('filters.clearAll' as Parameters<typeof t>[0])}
+        {t('filters.clearAll')}
       </button>
     </div>
   )

--- a/apps/presentation/features/productCollection/components/filter-drawer-footer.tsx
+++ b/apps/presentation/features/productCollection/components/filter-drawer-footer.tsx
@@ -21,7 +21,7 @@ export function FilterDrawerFooter({
         type='button'
         variant='tertiary'
         scheme='black'
-        size='none'
+        size='auto'
         onClick={onResetAll}
         className='gap-2 font-normal underline'
       >

--- a/apps/presentation/features/productCollection/components/filter-drawer-footer.tsx
+++ b/apps/presentation/features/productCollection/components/filter-drawer-footer.tsx
@@ -17,17 +17,20 @@ export function FilterDrawerFooter({
 
   return (
     <div className='absolute right-0 bottom-0 left-0 flex h-18 items-center justify-between border-t border-gray-200 bg-white px-3'>
-      <button
+      <Button
         type='button'
+        variant='tertiary'
+        scheme='black'
+        size='none'
         onClick={onResetAll}
-        className='flex cursor-pointer items-center gap-2 text-sm underline'
+        className='gap-2 font-normal underline'
       >
         <ReloadIcon
           className='h-4 w-4'
           aria-hidden='true'
         />
         {t('filters.resetAll' as Parameters<typeof t>[0])}
-      </button>
+      </Button>
 
       <Button onClick={onApplyFilters}>
         {t('filters.applyFilters' as Parameters<typeof t>[0])}

--- a/apps/presentation/features/productCollection/filter-drawer.tsx
+++ b/apps/presentation/features/productCollection/filter-drawer.tsx
@@ -24,12 +24,14 @@ import {
 import type { Facet } from '@core/contracts/product-collection/facet'
 import type { Filters } from '@core/contracts/product-collection/product-collection-page'
 import type { PriceRange } from '@core/contracts/product-collection/product-collection'
+import { Button } from '@/components/ui/button'
 import CloseIcon from '@/public/icons/close.svg'
 import { FacetAccordionItem } from './components/facet-accordion-item'
 import { PriceRangeAccordion } from './components/price-range-accordion'
 import { FilterDrawerFooter } from './components/filter-drawer-footer'
 
 interface FilterDrawerProps {
+  id?: string
   open: boolean
   onOpenChange: (open: boolean) => void
   currentSort: SortOption
@@ -51,6 +53,7 @@ interface FilterDrawerProps {
 }
 
 export function FilterDrawer({
+  id,
   open,
   onOpenChange,
   currentSort,
@@ -97,21 +100,25 @@ export function FilterDrawer({
       onOpenChange={onOpenChange}
     >
       <DialogContent
+        id={id}
         className='!inset-y-0 !top-0 !right-0 !left-auto flex h-full !max-h-full w-full max-w-full !translate-x-0 !translate-y-0 flex-col p-0 md:!inset-y-0 md:!top-0 md:!max-h-full md:w-96 md:max-w-96 md:!translate-y-0'
         showCloseButton={false}
       >
         <DialogHeader className='relative flex h-14 w-full items-center justify-between bg-white !px-4 py-4'>
-          <div className='relative h-6 w-6 shrink-0 opacity-0' />
+          <div className='relative size-8 shrink-0 opacity-0' />
           <DialogTitle className='text-base font-bold text-gray-950'>
             {t('filters.drawerTitle')}
           </DialogTitle>
-          <button
+          <Button
+            type='button'
+            variant='tertiary'
+            scheme='black'
+            size='icon-sm'
             onClick={() => onOpenChange(false)}
-            className='relative flex h-6 w-6 shrink-0 cursor-pointer items-center justify-center'
             aria-label={tCommon('close')}
           >
             <CloseIcon className='h-6 w-6 shrink-0 text-gray-700' />
-          </button>
+          </Button>
         </DialogHeader>
 
         <div className='flex-1 overflow-y-auto px-4 pb-24'>

--- a/apps/presentation/features/productCollection/product-collection-toolbar.tsx
+++ b/apps/presentation/features/productCollection/product-collection-toolbar.tsx
@@ -84,7 +84,7 @@ export function ProductCollectionToolbar({
               <Button
                 variant='tertiary'
                 scheme='black'
-                size='none'
+                size='auto'
                 onClick={onToggleCategories}
               >
                 {showCategories ? (

--- a/apps/presentation/features/productCollection/product-collection-toolbar.tsx
+++ b/apps/presentation/features/productCollection/product-collection-toolbar.tsx
@@ -13,6 +13,7 @@ import type { Facet } from '@core/contracts/product-collection/facet'
 import type { Filters } from '@core/contracts/product-collection/product-collection-page'
 import type { PriceRange } from '@core/contracts/product-collection/product-collection'
 import { cn } from '@/lib/utils'
+import { Button } from '@/components/ui/button'
 import OpenMenuIcon from '@/public/icons/open-menu.svg'
 import HideMenuIcon from '@/public/icons/hide-menu.svg'
 import { useFilterParams } from './hooks/use-filter-params'
@@ -65,6 +66,7 @@ export function ProductCollectionToolbar({
     sortOptions.find((opt) => opt.value === currentSort)?.label ?? ''
 
   const visibleFacets = facets.slice(0, VISIBLE_FACETS_COUNT)
+  const filterDrawerId = 'product-collection-filter-drawer'
 
   return (
     <>
@@ -79,9 +81,11 @@ export function ProductCollectionToolbar({
         <div className='flex shrink-0 items-center'>
           {showCategoriesButton && (
             <div className='hidden items-center gap-[30px] lg:flex'>
-              <button
+              <Button
+                variant='tertiary'
+                scheme='black'
+                size='none'
                 onClick={onToggleCategories}
-                className='flex cursor-pointer items-center gap-[5px] text-sm font-bold'
               >
                 {showCategories ? (
                   <HideMenuIcon className='h-4 w-4' />
@@ -91,7 +95,7 @@ export function ProductCollectionToolbar({
                 {showCategories
                   ? t('topbar.hideCategories')
                   : t('topbar.showCategories')}
-              </button>
+              </Button>
               <div className='h-16 w-px bg-gray-100' />
             </div>
           )}
@@ -114,7 +118,11 @@ export function ProductCollectionToolbar({
 
             {(facets.length > 0 || priceRange) && (
               <button
+                type='button'
                 onClick={() => setIsFilterDrawerOpen(true)}
+                aria-haspopup='dialog'
+                aria-expanded={isFilterDrawerOpen}
+                aria-controls={filterDrawerId}
                 className='flex h-10 cursor-pointer items-center gap-1 rounded-3xl bg-gray-100 px-4 text-sm font-bold'
               >
                 {t('topbar.allFilters')}
@@ -147,6 +155,7 @@ export function ProductCollectionToolbar({
       </div>
 
       <FilterDrawer
+        id={filterDrawerId}
         open={isFilterDrawerOpen}
         onOpenChange={setIsFilterDrawerOpen}
         currentSort={currentSort}

--- a/apps/presentation/features/wishlist/wishlist-toggle-button.tsx
+++ b/apps/presentation/features/wishlist/wishlist-toggle-button.tsx
@@ -69,7 +69,7 @@ export function WishlistToggleButton({
   if (variant === 'product-card') {
     return (
       <Button
-        size={showText ? 'none' : 'icon'}
+        size={showText ? 'auto' : 'icon'}
         scheme='white'
         className={cn(
           'absolute top-1 right-1 z-2 flex size-8 cursor-pointer border border-gray-100',
@@ -93,7 +93,7 @@ export function WishlistToggleButton({
 
   return (
     <Button
-      size={showText ? 'none' : 'icon-sm'}
+      size={showText ? 'auto' : 'icon-sm'}
       scheme='black'
       variant='tertiary'
       onClick={() => handleClick()}

--- a/apps/presentation/features/wishlist/wishlist-toggle-button.tsx
+++ b/apps/presentation/features/wishlist/wishlist-toggle-button.tsx
@@ -8,6 +8,7 @@ import { cn } from '@/lib/utils'
 import { useWishlistOperations } from './hooks/use-wishlist-operations'
 import { useWishlistProductIds } from './hooks/use-wishlist-product-ids'
 import { getWishlistItemKey } from './lib/get-wishlist-item-key'
+import { Button } from '@/components/ui/button'
 
 type WishlistToggleVariant = 'product-card' | 'cart'
 
@@ -67,14 +68,16 @@ export function WishlistToggleButton({
 
   if (variant === 'product-card') {
     return (
-      <button
-        type='button'
+      <Button
+        size={showText ? 'none' : 'icon'}
+        scheme='white'
         className={cn(
-          'absolute top-1 right-1 z-2 flex size-8 cursor-pointer items-center justify-center rounded-full border border-gray-100 bg-white disabled:opacity-50 lg:top-2 lg:right-2',
+          'absolute top-1 right-1 z-2 flex size-8 cursor-pointer border border-gray-100',
           className
         )}
         onClick={handleClick}
         disabled={isPending}
+        aria-pressed={isInWishlist}
         aria-label={
           isInWishlist ? t('wishlistRemoveAria') : t('wishlistSaveAria')
         }
@@ -84,21 +87,19 @@ export function WishlistToggleButton({
         ) : (
           <HeartIcon className='size-4 text-gray-700' />
         )}
-      </button>
+      </Button>
     )
   }
 
   return (
-    <button
-      type='button'
+    <Button
+      size={showText ? 'none' : 'icon-sm'}
+      scheme='black'
+      variant='tertiary'
       onClick={() => handleClick()}
       disabled={isPending}
-      className={cn(
-        'flex cursor-pointer items-center',
-        showText ? 'shrink-0 gap-2' : 'justify-center',
-        'disabled:cursor-not-allowed disabled:opacity-50',
-        className
-      )}
+      className={className}
+      aria-pressed={isInWishlist}
       aria-label={
         isInWishlist ? t('wishlistRemoveAria') : t('wishlistSaveAria')
       }
@@ -118,6 +119,6 @@ export function WishlistToggleButton({
           {labelText}
         </span>
       )}
-    </button>
+    </Button>
   )
 }

--- a/apps/storybook/src/stories/ui/ScrollButton.stories.tsx
+++ b/apps/storybook/src/stories/ui/ScrollButton.stories.tsx
@@ -13,10 +13,6 @@ const meta = {
       control: { type: 'radio' },
       options: ['left', 'right'],
     },
-    scheme: {
-      control: { type: 'radio' },
-      options: ['white', 'dark'],
-    },
     visible: {
       control: { type: 'boolean' },
     },
@@ -30,7 +26,6 @@ export const LeftVisible: Story = {
   args: {
     side: 'left',
     visible: true,
-    scheme: 'white',
     ariaLabel: 'Scroll left',
     onClick: () => {},
   },
@@ -40,7 +35,6 @@ export const RightVisible: Story = {
   args: {
     side: 'right',
     visible: true,
-    scheme: 'white',
     ariaLabel: 'Scroll right',
     onClick: () => {},
   },

--- a/apps/storybook/src/stories/ui/button.stories.tsx
+++ b/apps/storybook/src/stories/ui/button.stories.tsx
@@ -18,7 +18,7 @@ const meta = {
     },
     size: {
       control: { type: 'select' },
-      options: ['sm', 'default', 'lg', 'icon-sm', 'icon', 'icon-lg', 'none'],
+      options: ['sm', 'default', 'lg', 'icon-sm', 'icon', 'icon-lg', 'auto'],
     },
     scheme: {
       control: { type: 'select' },
@@ -114,6 +114,12 @@ export const Sizes: Story = {
         size='lg'
       >
         Large
+      </Button>
+      <Button
+        {...args}
+        size='auto'
+      >
+        Auto
       </Button>
     </div>
   ),

--- a/apps/storybook/src/stories/ui/button.stories.tsx
+++ b/apps/storybook/src/stories/ui/button.stories.tsx
@@ -16,6 +16,10 @@ const meta = {
       control: { type: 'select' },
       options: ['primary', 'secondary', 'tertiary'],
     },
+    size: {
+      control: { type: 'select' },
+      options: ['sm', 'default', 'lg', 'icon-sm', 'icon', 'icon-lg', 'none'],
+    },
     scheme: {
       control: { type: 'select' },
       options: ['red', 'white', 'black'],
@@ -30,6 +34,7 @@ const meta = {
   args: {
     children: 'Add to cart',
     variant: 'primary',
+    size: 'default',
     scheme: 'red',
     disabled: false,
     onClick: action('click'),
@@ -86,6 +91,59 @@ export const AsInternalLink: Story = {
     <Button {...args}>
       <Link href='/products/lightweight-rain-jacket'>{args.children}</Link>
     </Button>
+  ),
+}
+
+export const Sizes: Story = {
+  render: (args) => (
+    <div className='flex items-center gap-4'>
+      <Button
+        {...args}
+        size='sm'
+      >
+        Small
+      </Button>
+      <Button
+        {...args}
+        size='default'
+      >
+        Default
+      </Button>
+      <Button
+        {...args}
+        size='lg'
+      >
+        Large
+      </Button>
+    </div>
+  ),
+}
+
+export const IconOnly: Story = {
+  render: (args) => (
+    <div className='flex items-center gap-4'>
+      <Button
+        {...args}
+        size='icon-sm'
+        aria-label='Add to cart'
+      >
+        <CartIcon className='size-4' />
+      </Button>
+      <Button
+        {...args}
+        size='icon'
+        aria-label='Add to cart'
+      >
+        <CartIcon className='size-6' />
+      </Button>
+      <Button
+        {...args}
+        size='icon-lg'
+        aria-label='Add to cart'
+      >
+        <CartIcon className='size-7' />
+      </Button>
+    </div>
   ),
 }
 

--- a/apps/storybook/src/stories/ui/button.stories.tsx
+++ b/apps/storybook/src/stories/ui/button.stories.tsx
@@ -95,6 +95,9 @@ export const AsInternalLink: Story = {
 }
 
 export const Sizes: Story = {
+  argTypes: {
+    size: { table: { disable: true }, control: false },
+  },
   render: (args) => (
     <div className='flex items-center gap-4'>
       <Button
@@ -126,6 +129,9 @@ export const Sizes: Story = {
 }
 
 export const IconOnly: Story = {
+  argTypes: {
+    size: { table: { disable: true }, control: false },
+  },
   render: (args) => (
     <div className='flex items-center gap-4'>
       <Button

--- a/core/i18n/de-DE.json
+++ b/core/i18n/de-DE.json
@@ -25,6 +25,7 @@
     "viewAll": "Alle anzeigen",
     "navigation": "Navigation",
     "mobileNavigationMenu": "Mobile Navigation Menü",
+    "toggleMobileMenu": "Mobile Menü umschalten",
     "wishlist": "Wunschliste",
     "stores": "Stores",
     "shopinclub": "SHOPINCLUB",
@@ -62,7 +63,8 @@
     "gallery": {
       "loadMore": "Mehr Fotos laden",
       "dialogTitle": "Bildergalerie",
-      "dialogDescription": "Durch Produktbilder blättern"
+      "dialogDescription": "Durch Produktbilder blättern",
+      "closeButtonAria": "Galerie schließen"
     },
     "buyBox": {
       "size": "Größe",
@@ -128,6 +130,7 @@
       "specification-brakes": "Bremsen",
       "appliedFilters": "Angewandte Filter",
       "clearAll": "Alle Filter löschen",
+      "removeChipAria": "Filter {name} entfernen",
       "noResultsTitle": "Keine Produkte gefunden",
       "noResultsMessage": "Versuche, deine Filter anzupassen oder zurückzusetzen, um das Gesuchte zu finden.",
       "sizeShowMore": "+{count} mehr",
@@ -453,7 +456,7 @@
         "country": "Land",
         "email": "E-Mail"
       },
-      "additionalAddressLine": "+ Zusätzliche Adresszeile",
+      "additionalAddressLine": "Zusätzliche Adresszeile",
       "defaultShipping": "Standard Versand",
       "defaultBilling": "Standard Rechnung",
       "salutationOptions": {

--- a/core/i18n/en-US.json
+++ b/core/i18n/en-US.json
@@ -26,6 +26,7 @@
     "viewAll": "View all",
     "navigation": "Navigation",
     "mobileNavigationMenu": "Mobile navigation menu",
+    "toggleMobileMenu": "Toggle mobile menu",
     "wishlist": "Wishlist",
     "stores": "Stores",
     "shopinclub": "SHOPINCLUB",
@@ -63,7 +64,8 @@
     "gallery": {
       "loadMore": "Load more photos",
       "dialogTitle": "Image Gallery",
-      "dialogDescription": "Browse through product images"
+      "dialogDescription": "Browse through product images",
+      "closeButtonAria": "Close gallery"
     },
     "buyBox": {
       "size": "Size",
@@ -129,6 +131,7 @@
       "specification-brakes": "Brakes",
       "appliedFilters": "Applied filters",
       "clearAll": "Clear all filters",
+      "removeChipAria": "Remove {name} filter",
       "noResultsTitle": "No products found",
       "noResultsMessage": "Try adjusting or clearing your filters to find what you're looking for.",
       "sizeShowMore": "+{count} more",
@@ -454,7 +457,7 @@
         "country": "Country",
         "email": "Email"
       },
-      "additionalAddressLine": "+ Additional Address Line",
+      "additionalAddressLine": "Additional Address Line",
       "defaultShipping": "Default Shipping",
       "defaultBilling": "Default Billing",
       "salutationOptions": {


### PR DESCRIPTION
- add `size` variant (sm, default, lg, icon-sm, icon, icon-lg, none) to Button
- export `ButtonSize` type
- fix disabled state color gray-300 → gray-400
- fix secondary/white compound variant to solid white with dark text
- migrate all raw <button> elements to Button: ScrollButton, CarouselNavigation, GalleryDialog, Pagination, Toast, MobileMenuButton, MobileNavigation, WishlistToggleButton, FilterDrawer, FilterDrawerFooter, ProductCollectionToolbar
- refactor Pagination to use inline SVG icons instead of next/image
- remove `scheme` prop from ScrollButton (handled internally via Button)
- add `cursor: pointer` for non-disabled buttons in globals.css
- add `aria-pressed` to wishlist toggle buttons
- add `aria-haspopup` and `aria-controls` to filter/menu triggers
- add `aria-label` to chip remove and clear-all filter buttons
- connect FilterDrawer via id for ARIA
- add i18n keys: `toggleMobileMenu`, `gallery.closeButtonAria`, `filters.removeChipAria`
- fix `additionalAddressLine` label (remove leading `+`)
- add Button Storybook stories and update tests