### PR TITLE
fix: correct srcset for teasers, logo image props, and glass contrast

### DIFF
--- a/apps/presentation/app/globals.css
+++ b/apps/presentation/app/globals.css
@@ -185,7 +185,7 @@
 }
 
 @utility glass-filter {
-  background: rgba(15, 15, 15, 0.5);
+  background: rgba(15, 15, 15, 0.65);
   backdrop-filter: blur(15px);
   border: 1px solid rgba(255, 255, 255, 0.1);
   border-radius: 16px;

--- a/apps/presentation/components/layout/header.tsx
+++ b/apps/presentation/components/layout/header.tsx
@@ -31,7 +31,7 @@ export async function Header() {
               <Logo
                 className='h-10 w-32 flex-shrink-0'
                 src='/logo.svg'
-                priority
+                preload
               />
             </div>
 
@@ -54,7 +54,7 @@ export async function Header() {
               <Logo
                 className='h-12 w-40 flex-shrink-0'
                 src='/logo.svg'
-                priority
+                preload
               />
             </div>
 

--- a/apps/presentation/components/layout/header.tsx
+++ b/apps/presentation/components/layout/header.tsx
@@ -31,8 +31,7 @@ export async function Header() {
               <Logo
                 className='h-10 w-32 flex-shrink-0'
                 src='/logo.svg'
-                width={130}
-                height={40}
+                priority
               />
             </div>
 
@@ -55,8 +54,7 @@ export async function Header() {
               <Logo
                 className='h-12 w-40 flex-shrink-0'
                 src='/logo.svg'
-                width={150}
-                height={48}
+                priority
               />
             </div>
 

--- a/apps/presentation/components/layout/search-popup.tsx
+++ b/apps/presentation/components/layout/search-popup.tsx
@@ -114,8 +114,6 @@ export function SearchPopup({ open, onOpenChange }: SearchPopupProps) {
                 <Logo
                   src='/logo.svg'
                   className='h-12 w-40'
-                  width={150}
-                  height={48}
                 />
               </div>
               <DialogPrimitive.Close className='flex cursor-pointer items-center justify-center text-gray-950 lg:hidden'>

--- a/apps/presentation/components/ui/logo.tsx
+++ b/apps/presentation/components/ui/logo.tsx
@@ -9,7 +9,7 @@ interface LogoProps {
   className?: string
   alt?: string
   linkAriaLabel?: string
-  priority?: boolean
+  preload?: boolean
 }
 
 export const Logo: React.FC<LogoProps> = ({
@@ -17,7 +17,7 @@ export const Logo: React.FC<LogoProps> = ({
   className,
   alt,
   linkAriaLabel,
-  priority,
+  preload,
 }) => {
   const t = useTranslations('common')
   const resolvedAlt = alt || t('logoAlt')
@@ -36,7 +36,9 @@ export const Logo: React.FC<LogoProps> = ({
           fill
           sizes='200px'
           className='object-contain'
-          priority={priority}
+          {...(preload
+            ? { preload: true, fetchPriority: 'high' as const }
+            : {})}
         />
       </Link>
     </div>

--- a/apps/presentation/components/ui/logo.tsx
+++ b/apps/presentation/components/ui/logo.tsx
@@ -9,8 +9,7 @@ interface LogoProps {
   className?: string
   alt?: string
   linkAriaLabel?: string
-  width?: number
-  height?: number
+  priority?: boolean
 }
 
 export const Logo: React.FC<LogoProps> = ({
@@ -18,8 +17,7 @@ export const Logo: React.FC<LogoProps> = ({
   className,
   alt,
   linkAriaLabel,
-  width,
-  height,
+  priority,
 }) => {
   const t = useTranslations('common')
   const resolvedAlt = alt || t('logoAlt')
@@ -35,12 +33,10 @@ export const Logo: React.FC<LogoProps> = ({
         <Image
           src={src}
           alt={resolvedAlt}
-          width={width || 165}
-          height={height || 146}
-          className='h-full w-auto object-contain'
-          preload
-          loading='eager'
-          fetchPriority='high'
+          fill
+          sizes='200px'
+          className='object-contain'
+          priority={priority}
         />
       </Link>
     </div>

--- a/apps/presentation/features/content/content-image.tsx
+++ b/apps/presentation/features/content/content-image.tsx
@@ -36,24 +36,20 @@ export function ContentImage({
   const width = image.width
   const height = image.height
   const useFill = fill || width == null || height == null
+  const eagerProps = preload && {
+    loading: 'eager' as const,
+    fetchPriority: 'high' as const,
+  }
 
   return (
     <Image
       loader={contentImageLoader}
       src={url}
       alt={image.alt}
+      sizes={sizes}
       className={cn({ 'object-cover': useFill }, className)}
-      {...(useFill
-        ? {
-            fill: true,
-            sizes,
-            ...(preload && {
-              preload: true,
-              loading: 'eager',
-              fetchPriority: 'high',
-            }),
-          }
-        : { width: width!, height: height! })}
+      {...(useFill ? { fill: true } : { width: width!, height: height! })}
+      {...eagerProps}
     />
   )
 }

--- a/apps/presentation/features/content/content-image.tsx
+++ b/apps/presentation/features/content/content-image.tsx
@@ -18,8 +18,9 @@ type Props = {
  * Uses next/image with a loader that builds URLs (e.g. Contentful w/q/fm);
  * integrations pass a single base URL. Next.js calls the loader per width for srcset.
  *
- * Loading: next/image defaults to loading="lazy". When preload is true we also set
- * loading="eager" so the image loads immediately (LCP / above-the-fold).
+ * When `preload` is true, Next 16's `preload` prop is forwarded, which injects a
+ * `<link rel="preload">` into `<head>`, and `fetchPriority="high"` is set on the
+ * rendered img element (required for Lighthouse LCP audits).
  */
 export function ContentImage({
   image,
@@ -36,10 +37,6 @@ export function ContentImage({
   const width = image.width
   const height = image.height
   const useFill = fill || width == null || height == null
-  const eagerProps = preload && {
-    loading: 'eager' as const,
-    fetchPriority: 'high' as const,
-  }
 
   return (
     <Image
@@ -49,7 +46,7 @@ export function ContentImage({
       sizes={sizes}
       className={cn({ 'object-cover': useFill }, className)}
       {...(useFill ? { fill: true } : { width: width!, height: height! })}
-      {...eagerProps}
+      {...(preload ? { preload: true, fetchPriority: 'high' as const } : {})}
     />
   )
 }

--- a/apps/presentation/features/navigation/components/mobile-navigation/mobile-navigation.tsx
+++ b/apps/presentation/features/navigation/components/mobile-navigation/mobile-navigation.tsx
@@ -105,14 +105,11 @@ export function MobileNavigation({
           )}
 
           {currentLevel === 1 ? (
-            <div className='h-10 w-32'>
-              <Logo
-                src='/logo.svg'
-                alt='Logo'
-                width={130}
-                height={40}
-              />
-            </div>
+            <Logo
+              src='/logo.svg'
+              alt='Logo'
+              className='h-10 w-32'
+            />
           ) : currentLevel === 2 ? (
             <span className='max-w-50 truncate text-base font-normal'>
               {selectedCategory?.text}


### PR DESCRIPTION
    - ContentImage: always forward sizes and eager props to next/image regardless of fill vs fixed-dimension branch; Contentful images always carry width/height so fill={false} teasers were getting a 1x/2x srcset instead of a viewport-aware one

    - Logo: switch to fill prop — suppresses the next/image aspect-ratio warning caused by the SVG intrinsic ratio differing from the HTML attrs; replace invalid preload prop triple with priority; drop dead width/height props from all call sites

    - glass-filter: increase background opacity from 0.5 to 0.65 so white text has adequate contrast when the glass box extends outside the teaser image on mobile