### PR TITLE
feat: enrich variant attributes with localized labels from CT product type

### DIFF
--- a/apps/presentation/components/ui/configurable-options/__tests__/configurable-options.test.tsx
+++ b/apps/presentation/components/ui/configurable-options/__tests__/configurable-options.test.tsx
@@ -97,17 +97,17 @@ describe('ConfigurableOptions', () => {
         variants={[
           {
             id: variantId,
-            attributes: {
-              color: 'Black',
-              size: 'M',
-            },
+            attributes: [
+              { name: 'color', label: 'Color', value: 'Black' },
+              { name: 'size', label: 'Size', value: 'M' },
+            ],
           },
           {
             id: 'variant-456',
-            attributes: {
-              color: 'White',
-              size: 'S',
-            },
+            attributes: [
+              { name: 'color', label: 'Color', value: 'White' },
+              { name: 'size', label: 'Size', value: 'S' },
+            ],
           },
         ]}
       />
@@ -159,17 +159,17 @@ describe('ConfigurableOptions', () => {
         variants={[
           {
             id: variantId,
-            attributes: {
-              color: 'Black',
-              size: 'M',
-            },
+            attributes: [
+              { name: 'color', label: 'Color', value: 'Black' },
+              { name: 'size', label: 'Size', value: 'M' },
+            ],
           },
           {
             id: 'variant-456',
-            attributes: {
-              color: 'White',
-              size: 'S',
-            },
+            attributes: [
+              { name: 'color', label: 'Color', value: 'White' },
+              { name: 'size', label: 'Size', value: 'S' },
+            ],
           },
         ]}
       />

--- a/apps/presentation/components/ui/configurable-options/helpers.ts
+++ b/apps/presentation/components/ui/configurable-options/helpers.ts
@@ -23,7 +23,9 @@ export function buildSelectionFromVariantId(
   // excluding any non-selectable attributes that might exist in the variant
   const selectionByKey: Record<string, string> = {}
   options.forEach((optionDefinition) => {
-    const attributeValue = matchedVariant.attributes?.[optionDefinition.key]
+    const attributeValue = matchedVariant.attributes?.find(
+      (a) => a.name === optionDefinition.key
+    )?.value
     if (attributeValue) {
       selectionByKey[optionDefinition.key] = attributeValue
     }

--- a/apps/presentation/components/ui/configurable-options/use-configurable-selection.ts
+++ b/apps/presentation/components/ui/configurable-options/use-configurable-selection.ts
@@ -24,7 +24,8 @@ export function useConfigurableSelection(
   ) => {
     return Object.entries(selection).every(
       ([attributeKey, selectedValue]) =>
-        variant.attributes?.[attributeKey] === selectedValue
+        variant.attributes?.find((a) => a.name === attributeKey)?.value ===
+        selectedValue
     )
   }
 

--- a/apps/presentation/features/cart/components/variant-selector-modal.tsx
+++ b/apps/presentation/features/cart/components/variant-selector-modal.tsx
@@ -72,7 +72,8 @@ export function VariantSelectorModal({
 
     const selectedVariant = productData.product.variants.find((variant) => {
       return Object.entries(selectedOptions).every(
-        ([key, value]) => variant.attributes[key] === value
+        ([key, value]) =>
+          variant.attributes?.find((a) => a.name === key)?.value === value
       )
     })
 

--- a/core/contracts/src/product/product-details.ts
+++ b/core/contracts/src/product/product-details.ts
@@ -18,7 +18,13 @@ export const ProductDetailsResponseSchema = BaseEntityResponseSchema.extend({
     .array(
       z.object({
         id: z.string(),
-        attributes: z.record(z.string(), z.string()),
+        attributes: z.array(
+          z.object({
+            name: z.string(),
+            label: z.string(),
+            value: z.string(),
+          })
+        ),
       })
     )
     .optional(),

--- a/integrations/commercetools-api/src/mappers/configurable-options.ts
+++ b/integrations/commercetools-api/src/mappers/configurable-options.ts
@@ -4,23 +4,36 @@ import type {
   ImageOptionItemResponse,
 } from '@core/contracts/product/option-item'
 import type { ShopinVariantAttributes } from './variants'
+import type { AttributeDefinitionApiResponse } from '../schemas/attribute'
 import { isCssColor, parseColorPair } from '../helpers/color-utils'
+import { getLocalizedString } from '../helpers/get-localized-string'
+
+function resolveLabel(
+  attributeName: string,
+  defsByName: Record<string, AttributeDefinitionApiResponse> | undefined,
+  language: string
+): string {
+  return (
+    getLocalizedString(defsByName?.[attributeName]?.label, language) ??
+    attributeName
+  )
+}
 
 function buildOptionForAttribute(
   attributeName: string,
-  values: Set<string>
+  values: Set<string>,
+  label: string
 ): ConfigurableOptionResponse | undefined {
   const valueList = Array.from(values)
   return {
     key: attributeName,
-    label: attributeName,
+    label,
     type: 'string',
     options: valueList.map((label) => ({ label })),
   }
 }
 
 function buildColorOptionsForAttribute(
-  attributeName: string,
   values: Set<string>
 ): ColorOptionItemResponse[] | undefined {
   const valueList = Array.from(values)
@@ -103,7 +116,9 @@ export function collectAttributeValuesByName(
 
 export function mapConfigurableOptions(
   shopinVariants: ShopinVariantAttributes[],
-  variantIdToImage?: Record<string, string>
+  variantIdToImage?: Record<string, string>,
+  defsByName?: Record<string, AttributeDefinitionApiResponse>,
+  language = 'en'
 ): ConfigurableOptionResponse[] | undefined {
   const attrToValues = collectAttributeValuesByName(shopinVariants)
 
@@ -117,7 +132,9 @@ export function mapConfigurableOptions(
       attributeName,
       values,
       shopinVariants,
-      variantIdToImage
+      variantIdToImage,
+      defsByName,
+      language
     )
     if (chosen) {
       options.push(chosen)
@@ -131,9 +148,12 @@ function chooseConfigurableOptionForAttribute(
   attributeName: string,
   values: Set<string>,
   shopinVariants: ShopinVariantAttributes[],
-  variantIdToImage?: Record<string, string>
+  variantIdToImage?: Record<string, string>,
+  defsByName?: Record<string, AttributeDefinitionApiResponse>,
+  language = 'en'
 ) {
-  // Prefer image option when image mapping is provided and viable
+  const label = resolveLabel(attributeName, defsByName, language)
+
   const imageOptions = buildImageOptionsForAttribute(
     attributeName,
     shopinVariants,
@@ -142,22 +162,21 @@ function chooseConfigurableOptionForAttribute(
   if (imageOptions) {
     return {
       key: attributeName,
-      label: attributeName,
+      label,
       type: 'image' as const,
       options: imageOptions,
     }
   }
 
-  // Next, prefer color when all values look colorish or label:color pairs
-  const colorOptions = buildColorOptionsForAttribute(attributeName, values)
+  const colorOptions = buildColorOptionsForAttribute(values)
   if (colorOptions) {
     return {
       key: attributeName,
-      label: attributeName,
+      label,
       type: 'color' as const,
       options: colorOptions,
     }
   }
 
-  return buildOptionForAttribute(attributeName, values)
+  return buildOptionForAttribute(attributeName, values, label)
 }

--- a/integrations/commercetools-api/src/mappers/variants.ts
+++ b/integrations/commercetools-api/src/mappers/variants.ts
@@ -5,10 +5,17 @@ import type {
 import type { ProductVariantApiResponse } from '../schemas/product-variant'
 import { stringifySelectableAttributeValue } from '../helpers/stringify-selectable-attribute-value'
 import { isSelectableAttribute } from '../helpers/is-selectable-attribute'
+import { getLocalizedString } from '../helpers/get-localized-string'
 
 export interface ShopinVariantAttributes {
   id: string
   attributes: Record<string, string>
+}
+
+export interface VariantAttributeDetail {
+  name: string
+  label: string
+  value: string
 }
 
 export function mapVariantAttributes(
@@ -71,5 +78,20 @@ export function mapVariantsToShopin(
         varyingAttributeNames.has(name)
       )
     ),
+  }))
+}
+
+export function mapVariantsToResponse(
+  shopinVariants: ShopinVariantAttributes[],
+  defsByName?: Record<string, AttributeDefinitionApiResponse>,
+  language = 'en'
+): { id: string; attributes: VariantAttributeDetail[] }[] {
+  return shopinVariants.map(({ id, attributes }) => ({
+    id,
+    attributes: Object.entries(attributes).map(([name, value]) => {
+      const def = defsByName?.[name]
+      const label = getLocalizedString(def?.label, language) ?? name
+      return { name, label, value }
+    }),
   }))
 }

--- a/integrations/commercetools-api/src/services/product.service.ts
+++ b/integrations/commercetools-api/src/services/product.service.ts
@@ -11,7 +11,7 @@ import { mapVariantPriceToShopin } from '../mappers/price'
 import { mapBadges } from '../mappers/badges'
 import { mapConfigurableOptions } from '../mappers/configurable-options'
 import { mapVariantToGallery } from '../mappers/gallery'
-import { mapVariantsToShopin } from '../mappers/variants'
+import { mapVariantsToShopin, mapVariantsToResponse } from '../mappers/variants'
 import { ProductProjectionPagedQueryApiResponseSchema } from '../schemas/product-projection'
 import type { Category, LocalizedString } from '@commercetools/platform-sdk'
 
@@ -94,6 +94,7 @@ export class ProductService {
       currentLanguage,
       defsByName
     )
+
     const variantIdToImage: Record<string, string> = Object.fromEntries(
       allVariants
         .map(
@@ -104,7 +105,9 @@ export class ProductService {
     )
     const configurableOptions = mapConfigurableOptions(
       shopinVariants,
-      variantIdToImage
+      variantIdToImage,
+      defsByName,
+      currentLanguage
     )
 
     return {
@@ -129,7 +132,11 @@ export class ProductService {
         badges,
         // deliveryEstimate is not available from commercetools by default
         configurableOptions,
-        variants: shopinVariants,
+        variants: mapVariantsToResponse(
+          shopinVariants,
+          defsByName,
+          currentLanguage
+        ),
       },
       breadcrumb: [
         ...this.resolveCategoryBreadcrumb(

--- a/integrations/mock-api/src/generators/shopin-product-variants.ts
+++ b/integrations/mock-api/src/generators/shopin-product-variants.ts
@@ -7,7 +7,8 @@ import type {
 
 type Faker = ReturnType<MockApi['getFaker']>
 
-type Variant = { id: string; attributes: Record<string, string> }
+type AttributeDetail = { name: string; label: string; value: string }
+type Variant = { id: string; attributes: AttributeDetail[] }
 
 function buildAllVariantCombinations(
   colors: ColorOptionItemResponse[],
@@ -23,11 +24,11 @@ function buildAllVariantCombinations(
             styleIndex +
             1
         ),
-        attributes: {
-          color: color.label,
-          size: size.label,
-          style: style.label,
-        },
+        attributes: [
+          { name: 'color', label: 'Color', value: color.label },
+          { name: 'size', label: 'Size', value: size.label },
+          { name: 'style', label: 'Style', value: style.label },
+        ],
       }))
     )
   )
@@ -36,7 +37,7 @@ function buildAllVariantCombinations(
 function groupByColor(variants: Variant[]): Map<string, Variant[]> {
   const byColor = new Map<string, Variant[]>()
   variants.forEach((variant) => {
-    const key = variant.attributes.color
+    const key = variant.attributes.find((a) => a.name === 'color')?.value ?? ''
     const arr = byColor.get(key) || []
     arr.push(variant)
     byColor.set(key, arr)
@@ -69,7 +70,7 @@ export function createShopinProductVariants(
   colors: ColorOptionItemResponse[],
   sizes: ValueOptionItemResponse[],
   styles: ImageOptionItemResponse[]
-): Array<{ id: string; attributes: Record<string, string> }> {
+): Variant[] {
   const all = buildAllVariantCombinations(colors, sizes, styles)
   const grouped = groupByColor(all)
   return chooseVariantsPerColor(faker, grouped)


### PR DESCRIPTION

Variant attributes in the product API response are now returned as an array of {name, label, value} objects instead of a flat Record<string,string>.