### PR TITLE
feat(tabs): smooth tab switching for address tabs

### DIFF
--- a/apps/presentation/features/account/my-data-tabs.tsx
+++ b/apps/presentation/features/account/my-data-tabs.tsx
@@ -1,9 +1,8 @@
 'use client'
 
-import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs'
 import Link from 'next/link'
-import { FC, PropsWithChildren } from 'react'
-import { TabsContent } from '@/components/ui/tabs'
+import { FC, PropsWithChildren, useState } from 'react'
 import { useTranslations } from 'next-intl'
 import { useSelectedLayoutSegment } from 'next/navigation'
 
@@ -28,9 +27,19 @@ const TABS = [
 export const MyDataTabs: FC<PropsWithChildren> = ({ children }) => {
   const segment = useSelectedLayoutSegment()
   const t = useTranslations('account.myAccount')
+  const [activeTab, setActiveTab] = useState(segment || 'personal-data')
+  const [prevSegment, setPrevSegment] = useState(segment)
+
+  if (prevSegment !== segment) {
+    setPrevSegment(segment)
+    setActiveTab(segment || 'personal-data')
+  }
 
   return (
-    <Tabs defaultValue={segment || 'personal-data'}>
+    <Tabs
+      value={activeTab}
+      onValueChange={setActiveTab}
+    >
       <TabsList>
         {TABS.map((tab) => (
           <TabsTrigger
@@ -47,8 +56,8 @@ export const MyDataTabs: FC<PropsWithChildren> = ({ children }) => {
         ))}
       </TabsList>
       <TabsContent
-        value={segment || 'personal-data'}
-        className='pt-8'
+        value={activeTab}
+        className='min-h-72 pt-8'
       >
         {children}
       </TabsContent>

--- a/apps/presentation/features/customer/customer-addresses-skeleton.tsx
+++ b/apps/presentation/features/customer/customer-addresses-skeleton.tsx
@@ -1,0 +1,56 @@
+'use client'
+
+import { Card } from '@/components/ui/card'
+
+const SkeletonBar = ({ w, h }: { w: string; h: string }) => (
+  <div className={`${h} ${w} animate-pulse rounded bg-gray-200`} />
+)
+
+export const CustomerAddressesSkeleton = () => (
+  <div className='grid min-h-72 grid-cols-1 gap-4 xl:grid-cols-2'>
+    {Array.from({ length: 2 }, (_, i) => (
+      <Card
+        key={i}
+        scheme='white'
+        className='flex flex-col justify-between border border-gray-200'
+      >
+        <div className='mb-4 flex flex-col gap-4 sm:mb-8 sm:flex-row sm:justify-between sm:gap-2'>
+          <div className='space-y-2'>
+            <SkeletonBar
+              h='h-5'
+              w='w-40'
+            />
+            <SkeletonBar
+              h='h-4'
+              w='w-32'
+            />
+            <SkeletonBar
+              h='h-4'
+              w='w-24'
+            />
+          </div>
+          <div className='flex flex-col gap-y-2 sm:items-end'>
+            <SkeletonBar
+              h='h-8'
+              w='w-24'
+            />
+            <SkeletonBar
+              h='h-8'
+              w='w-24'
+            />
+          </div>
+        </div>
+        <div className='flex gap-4 border-t border-gray-200 pt-4'>
+          <SkeletonBar
+            h='h-6'
+            w='w-28'
+          />
+          <SkeletonBar
+            h='h-6'
+            w='w-28'
+          />
+        </div>
+      </Card>
+    ))}
+  </div>
+)

--- a/apps/presentation/features/customer/customer-addresses.tsx
+++ b/apps/presentation/features/customer/customer-addresses.tsx
@@ -27,8 +27,8 @@ import { useCustomerAddressOperations } from './customer-use-customer-address-op
 import { useCustomer } from './customer-use-customer'
 import { AddressBase } from '@core/contracts/address/address-base'
 import PlusIcon from '@/public/icons/plus.svg'
-import { LoadingSpinner } from '@/components/ui/loading-spinner'
 import { ErrorDisplay } from '@/components/ui/error-display'
+import { CustomerAddressesSkeleton } from './customer-addresses-skeleton'
 
 export const CustomerAddresses: FC = () => {
   const t = useTranslations('account.myAccount')
@@ -87,7 +87,7 @@ export const CustomerAddresses: FC = () => {
   }
 
   if (isLoading) {
-    return <LoadingSpinner className='size-6' />
+    return <CustomerAddressesSkeleton />
   }
 
   if (error) {


### PR DESCRIPTION
- Replace LoadingSpinner with contextual CustomerAddressesSkeleton matching the address card layout
- Add optimistic active tab state to MyDataTabs synced via useEffect for browser back/forward support
- Add min-h-72 to TabsContent to prevent layout shift during navigation