### PR TITLE
fix(storybook): use relative image paths to fix broken assets on prod

### DIFF
--- a/apps/storybook/src/stories/ui/carousel.stories.tsx
+++ b/apps/storybook/src/stories/ui/carousel.stories.tsx
@@ -10,7 +10,7 @@ const PRODUCTS = [
     name: 'Running Shoes',
     price: { regularPriceInCents: 2999, currency: 'EUR', fractionDigits: 2 },
     image: {
-      src: '/product-image.png',
+      src: 'product-image.png',
       alt: 'Running Shoes',
     },
   },
@@ -20,7 +20,7 @@ const PRODUCTS = [
     name: 'Cotton Overshirt',
     price: { regularPriceInCents: 8999, currency: 'EUR', fractionDigits: 2 },
     image: {
-      src: '/product-image.png',
+      src: 'product-image.png',
       alt: 'Cotton Overshirt',
     },
   },
@@ -30,7 +30,7 @@ const PRODUCTS = [
     name: 'Weekend Bag',
     price: { regularPriceInCents: 19999, currency: 'EUR', fractionDigits: 2 },
     image: {
-      src: '/product-image.png',
+      src: 'product-image.png',
       alt: 'Weekend Bag',
     },
   },
@@ -40,7 +40,7 @@ const PRODUCTS = [
     name: 'Linen Shirt',
     price: { regularPriceInCents: 5999, currency: 'EUR', fractionDigits: 2 },
     image: {
-      src: '/product-image.png',
+      src: 'product-image.png',
       alt: 'Linen Shirt',
     },
   },
@@ -50,7 +50,7 @@ const PRODUCTS = [
     name: 'Denim Jacket',
     price: { regularPriceInCents: 7999, currency: 'EUR', fractionDigits: 2 },
     image: {
-      src: '/product-image.png',
+      src: 'product-image.png',
       alt: 'Denim Jacket',
     },
   },
@@ -60,7 +60,7 @@ const PRODUCTS = [
     name: 'Travel Backpack',
     price: { regularPriceInCents: 14999, currency: 'EUR', fractionDigits: 2 },
     image: {
-      src: '/product-image.png',
+      src: 'product-image.png',
       alt: 'Travel Backpack',
     },
   },

--- a/apps/storybook/src/stories/ui/gallery-image.stories.tsx
+++ b/apps/storybook/src/stories/ui/gallery-image.stories.tsx
@@ -15,7 +15,7 @@ type Story = StoryObj<typeof meta>
 
 export const Default: Story = {
   args: {
-    src: '/product-image.png',
+    src: 'product-image.png',
     alt: 'Product image',
   },
   render: (args) => (

--- a/apps/storybook/src/stories/ui/product-grid.stories.tsx
+++ b/apps/storybook/src/stories/ui/product-grid.stories.tsx
@@ -13,7 +13,7 @@ const mockProducts = [
     name: 'Classic White T-Shirt',
     price: { regularPriceInCents: 2999, currency: 'EUR', fractionDigits: 2 },
     image: {
-      src: '/product-image.png',
+      src: 'product-image.png',
       alt: 'White T-Shirt',
     },
   },
@@ -23,7 +23,7 @@ const mockProducts = [
     name: 'Denim Jeans',
     price: { regularPriceInCents: 8999, currency: 'EUR', fractionDigits: 2 },
     image: {
-      src: '/product-image.png',
+      src: 'product-image.png',
       alt: 'Denim Jeans',
     },
   },
@@ -33,7 +33,7 @@ const mockProducts = [
     name: 'Leather Jacket',
     price: { regularPriceInCents: 19999, currency: 'EUR', fractionDigits: 2 },
     image: {
-      src: '/product-image.png',
+      src: 'product-image.png',
       alt: 'Leather Jacket',
     },
   },
@@ -43,7 +43,7 @@ const mockProducts = [
     name: 'Summer Dress',
     price: { regularPriceInCents: 5999, currency: 'EUR', fractionDigits: 2 },
     image: {
-      src: '/product-image.png',
+      src: 'product-image.png',
       alt: 'Summer Dress',
     },
   },
@@ -53,7 +53,7 @@ const mockProducts = [
     name: 'Sneakers',
     price: { regularPriceInCents: 7999, currency: 'EUR', fractionDigits: 2 },
     image: {
-      src: '/product-image.png',
+      src: 'product-image.png',
       alt: 'Sneakers',
     },
   },
@@ -63,7 +63,7 @@ const mockProducts = [
     name: 'Winter Coat',
     price: { regularPriceInCents: 14999, currency: 'EUR', fractionDigits: 2 },
     image: {
-      src: '/product-image.png',
+      src: 'product-image.png',
       alt: 'Winter Coat',
     },
   },


### PR DESCRIPTION
Absolute paths bypass the <base href="/storybook/"> tag injected in production builds, causing images to 404. Relative paths resolve correctly via the base tag in both local and production environments.