### PR TITLE
feat: use Contentful and commercetools CDNs for responsive image scaling

### DIFF
--- a/apps/presentation/components/ui/configurable-options/selectors/thumbnail-selector.tsx
+++ b/apps/presentation/components/ui/configurable-options/selectors/thumbnail-selector.tsx
@@ -4,6 +4,7 @@
 import React from 'react'
 import Image from 'next/image'
 import { cn } from '@/lib/utils'
+import { productImageLoader } from '@/lib/product-image-loader'
 import type { ImageOptionItemResponse } from '@core/contracts/product/option-item'
 import type { SelectorComponentProps } from './selector-registry'
 import { getSelectorLayoutClass } from './selector-utils'
@@ -53,6 +54,7 @@ export const ThumbnailSelector: React.FC<ThumbnailSelectorProps> = ({
               )}
             >
               <Image
+                loader={productImageLoader}
                 src={opt.imageSrc}
                 alt={opt.label}
                 width={layout === 'grid' ? 200 : 60}

--- a/apps/presentation/components/ui/configurable-options/selectors/thumbnail-selector.tsx
+++ b/apps/presentation/components/ui/configurable-options/selectors/thumbnail-selector.tsx
@@ -54,7 +54,7 @@ export const ThumbnailSelector: React.FC<ThumbnailSelectorProps> = ({
               )}
             >
               <Image
-                loader={productImageLoader}
+                loader={productImageLoader(opt.imageSrc)}
                 src={opt.imageSrc}
                 alt={opt.label}
                 width={layout === 'grid' ? 200 : 60}

--- a/apps/presentation/components/ui/gallery-dialog.tsx
+++ b/apps/presentation/components/ui/gallery-dialog.tsx
@@ -2,6 +2,7 @@
 
 import React, { useEffect, useRef } from 'react'
 import Image from 'next/image'
+import { productImageLoader } from '@/lib/product-image-loader'
 import { useTranslations } from 'next-intl'
 import CloseIcon from '@/public/icons/close.svg'
 import { Carousel, CarouselSlide } from '@/components/ui/carousel'
@@ -86,6 +87,7 @@ export const GalleryDialog: React.FC<GalleryDialogProps> = ({
       >
         <div className='flex h-full max-h-screen w-full items-center justify-center p-4'>
           <Image
+            loader={productImageLoader}
             src={item.src}
             alt={item.alt || ''}
             width={imageWidth}

--- a/apps/presentation/components/ui/gallery-dialog.tsx
+++ b/apps/presentation/components/ui/gallery-dialog.tsx
@@ -87,7 +87,7 @@ export const GalleryDialog: React.FC<GalleryDialogProps> = ({
       >
         <div className='flex h-full max-h-screen w-full items-center justify-center p-4'>
           <Image
-            loader={productImageLoader}
+            loader={productImageLoader(item.src)}
             src={item.src}
             alt={item.alt || ''}
             width={imageWidth}

--- a/apps/presentation/components/ui/gallery-image.tsx
+++ b/apps/presentation/components/ui/gallery-image.tsx
@@ -47,7 +47,7 @@ export const GalleryImage: React.FC<GalleryImageProps> = ({
       })}
     >
       <Image
-        loader={productImageLoader}
+        loader={productImageLoader(src)}
         src={src}
         alt={alt}
         fill

--- a/apps/presentation/components/ui/gallery-image.tsx
+++ b/apps/presentation/components/ui/gallery-image.tsx
@@ -3,6 +3,7 @@
 import React from 'react'
 import Image from 'next/image'
 import { cn } from '@/lib/utils'
+import { productImageLoader } from '@/lib/product-image-loader'
 
 export interface GalleryImageProps {
   src: string
@@ -10,6 +11,7 @@ export interface GalleryImageProps {
   onZoom?: () => void
   className?: string
   loading?: 'lazy' | 'eager'
+  sizes?: string
 }
 
 export const GalleryImage: React.FC<GalleryImageProps> = ({
@@ -18,6 +20,7 @@ export const GalleryImage: React.FC<GalleryImageProps> = ({
   onZoom,
   className,
   loading,
+  sizes,
 }) => {
   const isInteractive = Boolean(onZoom)
 
@@ -44,9 +47,11 @@ export const GalleryImage: React.FC<GalleryImageProps> = ({
       })}
     >
       <Image
+        loader={productImageLoader}
         src={src}
         alt={alt}
         fill
+        sizes={sizes}
         className='object-contain'
         loading={loading}
       />

--- a/apps/presentation/components/ui/product-card.tsx
+++ b/apps/presentation/components/ui/product-card.tsx
@@ -58,7 +58,7 @@ export const ProductCard: React.FC<ProductCardProps> = ({
           </div>
         )}
         <Image
-          loader={productImageLoader}
+          loader={productImageLoader(data.image.src)}
           src={data.image.src}
           alt={data.image.alt || data.name}
           fill

--- a/apps/presentation/components/ui/product-card.tsx
+++ b/apps/presentation/components/ui/product-card.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import Image from 'next/image'
 import Link from 'next/link'
+import { productImageLoader } from '@/lib/product-image-loader'
 import type { LinkProps } from 'next/link'
 import { cn } from '@/lib/utils'
 import type { ProductCardResponse } from '@core/contracts/product-collection/product-card'
@@ -57,6 +58,7 @@ export const ProductCard: React.FC<ProductCardProps> = ({
           </div>
         )}
         <Image
+          loader={productImageLoader}
           src={data.image.src}
           alt={data.image.alt || data.name}
           fill

--- a/apps/presentation/components/ui/product-gallery.tsx
+++ b/apps/presentation/components/ui/product-gallery.tsx
@@ -43,6 +43,7 @@ export const ProductGallery: React.FC<ProductGalleryProps> = ({
       src={img.src}
       alt={img.alt}
       onZoom={() => openDialog(idx)}
+      sizes='(max-width: 1023px) 80vw, 50vw'
       loading={idx < visibleCount ? 'eager' : undefined}
     />
   ))
@@ -60,6 +61,7 @@ export const ProductGallery: React.FC<ProductGalleryProps> = ({
         src={img.src}
         alt={img.alt}
         onZoom={() => openDialog(idx)}
+        sizes='(max-width: 1023px) 80vw, 50vw'
         className='h-full lg:aspect-square lg:h-auto'
         loading={idx === 0 ? 'eager' : undefined}
       />

--- a/apps/presentation/components/ui/product-gallery.tsx
+++ b/apps/presentation/components/ui/product-gallery.tsx
@@ -18,6 +18,15 @@ export interface ProductGalleryProps extends ProductGalleryResponse {
   video?: { src: string; poster: string; alt?: string }
 }
 
+// Desktop grid is hidden below 1024px; 1px fallback tells the browser to pick the
+// smallest srcset entry for CSS-hidden tiles rather than defaulting to 100vw.
+const DESKTOP_GRID_SIZES =
+  '(min-width: 1920px) 708px, (min-width: 1024px) calc((100vw - 32rem) / 2), 1px'
+
+// Carousel is hidden at 1024px and above (lg:hidden); same rationale as above.
+const CAROUSEL_SIZES =
+  '(max-width: 639px) 83vw, (max-width: 767px) 67vw, (max-width: 1023px) 31vw, 1px'
+
 export const ProductGallery: React.FC<ProductGalleryProps> = ({
   images,
   className,
@@ -43,7 +52,7 @@ export const ProductGallery: React.FC<ProductGalleryProps> = ({
       src={img.src}
       alt={img.alt}
       onZoom={() => openDialog(idx)}
-      sizes='(max-width: 1023px) 80vw, 50vw'
+      sizes={DESKTOP_GRID_SIZES}
       loading={idx < visibleCount ? 'eager' : undefined}
     />
   ))
@@ -61,7 +70,7 @@ export const ProductGallery: React.FC<ProductGalleryProps> = ({
         src={img.src}
         alt={img.alt}
         onZoom={() => openDialog(idx)}
-        sizes='(max-width: 1023px) 80vw, 50vw'
+        sizes={CAROUSEL_SIZES}
         className='h-full lg:aspect-square lg:h-auto'
         loading={idx === 0 ? 'eager' : undefined}
       />

--- a/apps/presentation/features/cart/components/cart-item/cart-item-compact.tsx
+++ b/apps/presentation/features/cart/components/cart-item/cart-item-compact.tsx
@@ -41,7 +41,7 @@ export function CartItemCompact({
             {item.imageUrl && (
               <div className='relative h-28 w-24 shrink-0 overflow-hidden'>
                 <Image
-                  loader={productImageLoader}
+                  loader={productImageLoader(item.imageUrl)}
                   src={item.imageUrl}
                   alt={item.name}
                   fill

--- a/apps/presentation/features/cart/components/cart-item/cart-item-compact.tsx
+++ b/apps/presentation/features/cart/components/cart-item/cart-item-compact.tsx
@@ -2,6 +2,7 @@
 
 import Image from 'next/image'
 import Link from 'next/link'
+import { productImageLoader } from '@/lib/product-image-loader'
 import type { LineItemResponse } from '@core/contracts/cart/cart'
 import { CartItemActions } from './cart-item-actions'
 import { CartItemQuantitySwitcher } from './cart-item-quantity-switcher'
@@ -40,6 +41,7 @@ export function CartItemCompact({
             {item.imageUrl && (
               <div className='relative h-28 w-24 shrink-0 overflow-hidden'>
                 <Image
+                  loader={productImageLoader}
                   src={item.imageUrl}
                   alt={item.name}
                   fill

--- a/apps/presentation/features/cart/components/cart-item/cart-item.tsx
+++ b/apps/presentation/features/cart/components/cart-item/cart-item.tsx
@@ -35,7 +35,7 @@ export function CartItem({ item }: CartItemProps) {
         {item.imageUrl && (
           <div className='relative h-28 w-24 shrink-0 overflow-hidden md:row-span-3 md:h-56 md:w-44'>
             <Image
-              loader={productImageLoader}
+              loader={productImageLoader(item.imageUrl)}
               src={item.imageUrl}
               alt={item.name}
               fill

--- a/apps/presentation/features/cart/components/cart-item/cart-item.tsx
+++ b/apps/presentation/features/cart/components/cart-item/cart-item.tsx
@@ -2,6 +2,7 @@
 
 import Image from 'next/image'
 import Link from 'next/link'
+import { productImageLoader } from '@/lib/product-image-loader'
 import type { LineItemResponse } from '@core/contracts/cart/cart'
 import { CartItemActions } from './cart-item-actions'
 import { CartItemQuantitySwitcher } from './cart-item-quantity-switcher'
@@ -34,6 +35,7 @@ export function CartItem({ item }: CartItemProps) {
         {item.imageUrl && (
           <div className='relative h-28 w-24 shrink-0 overflow-hidden md:row-span-3 md:h-56 md:w-44'>
             <Image
+              loader={productImageLoader}
               src={item.imageUrl}
               alt={item.name}
               fill

--- a/apps/presentation/features/content/lib/content-image-loader.ts
+++ b/apps/presentation/features/content/lib/content-image-loader.ts
@@ -11,17 +11,10 @@ import {
   CONTENT_IMAGE_API_HOSTS,
   CONTENT_IMAGE_DEFAULT_QUALITY,
 } from '@config/constants'
+import { isHostSupported } from '@/lib/image-host-utils'
 
 function contentHostSupportsImageApi(url: string): boolean {
-  try {
-    const absolute = url.startsWith('//') ? `https:${url}` : url
-    const host = new URL(absolute).hostname
-    return CONTENT_IMAGE_API_HOSTS.some(
-      (h) => host === h || host.endsWith('.' + h)
-    )
-  } catch {
-    return false
-  }
+  return isHostSupported(url, CONTENT_IMAGE_API_HOSTS)
 }
 
 export type ContentImageLoaderParams = {

--- a/apps/presentation/features/content/teasers/lazy-video.tsx
+++ b/apps/presentation/features/content/teasers/lazy-video.tsx
@@ -2,6 +2,7 @@
 
 import { useRef, useState, useEffect } from 'react'
 import Image from 'next/image'
+import { contentImageLoader } from '../lib/content-image-loader'
 import PlayIcon from '@/public/icons/play.svg'
 import { cn } from '@/lib/utils'
 import { useTranslations } from 'next-intl'
@@ -105,6 +106,7 @@ export function LazyVideo({
               aria-label={t('video.play')}
             >
               <Image
+                loader={contentImageLoader}
                 src={poster}
                 alt=''
                 fill

--- a/apps/presentation/features/navigation/components/main-navigation.tsx
+++ b/apps/presentation/features/navigation/components/main-navigation.tsx
@@ -4,6 +4,7 @@ import * as React from 'react'
 import { createPortal } from 'react-dom'
 import Link from 'next/link'
 import Image from 'next/image'
+import { productImageLoader } from '@/lib/product-image-loader'
 import { cn } from '@/lib/utils'
 import { HorizontalScroller } from '@/components/ui/horizontal-scroller'
 import type { MainNavigationResponse } from '@core/contracts/navigation/main-navigation'
@@ -191,6 +192,7 @@ export const MainNavigation: React.FC<MainNavigationProps> = ({
                   >
                     <div className='relative aspect-square w-full'>
                       <Image
+                        loader={productImageLoader}
                         src={activeItem.featuredProduct.image.src}
                         alt={activeItem.featuredProduct.image.alt}
                         fill

--- a/apps/presentation/features/navigation/components/main-navigation.tsx
+++ b/apps/presentation/features/navigation/components/main-navigation.tsx
@@ -192,7 +192,9 @@ export const MainNavigation: React.FC<MainNavigationProps> = ({
                   >
                     <div className='relative aspect-square w-full'>
                       <Image
-                        loader={productImageLoader}
+                        loader={productImageLoader(
+                          activeItem.featuredProduct.image.src
+                        )}
                         src={activeItem.featuredProduct.image.src}
                         alt={activeItem.featuredProduct.image.alt}
                         fill

--- a/apps/presentation/features/order-history/components/line-item-images.tsx
+++ b/apps/presentation/features/order-history/components/line-item-images.tsx
@@ -39,7 +39,7 @@ export const LineItemImages: FC<LineItemImagesProps> = ({
             )}
           >
             <Image
-              loader={productImageLoader}
+              loader={productImageLoader(img.url)}
               src={img.url}
               alt={img.alt || ''}
               fill

--- a/apps/presentation/features/order-history/components/line-item-images.tsx
+++ b/apps/presentation/features/order-history/components/line-item-images.tsx
@@ -1,6 +1,7 @@
 import { FC } from 'react'
 import Image from 'next/image'
 import { cn } from '@/lib/utils'
+import { productImageLoader } from '@/lib/product-image-loader'
 
 interface LineItemImagesProps {
   images: { url: string; alt?: string }[]
@@ -38,6 +39,7 @@ export const LineItemImages: FC<LineItemImagesProps> = ({
             )}
           >
             <Image
+              loader={productImageLoader}
               src={img.url}
               alt={img.alt || ''}
               fill

--- a/apps/presentation/features/order-history/components/order-detail-line-item.tsx
+++ b/apps/presentation/features/order-history/components/order-detail-line-item.tsx
@@ -23,7 +23,7 @@ export const OrderDetailLineItem: FC<OrderDetailLineItemProps> = ({
       {item.imageUrl ? (
         <div className='relative h-28 w-28 shrink-0 overflow-hidden rounded border border-gray-200 bg-gray-50'>
           <Image
-            loader={productImageLoader}
+            loader={productImageLoader(item.imageUrl)}
             src={item.imageUrl}
             alt={item.name}
             fill

--- a/apps/presentation/features/order-history/components/order-detail-line-item.tsx
+++ b/apps/presentation/features/order-history/components/order-detail-line-item.tsx
@@ -1,5 +1,6 @@
 import { type FC } from 'react'
 import Image from 'next/image'
+import { productImageLoader } from '@/lib/product-image-loader'
 import { useTranslations } from 'next-intl'
 import type { OrderResponse } from '@core/contracts/order/order'
 import { FormattedPrice } from '@/components/ui/price/formatted-price'
@@ -22,6 +23,7 @@ export const OrderDetailLineItem: FC<OrderDetailLineItemProps> = ({
       {item.imageUrl ? (
         <div className='relative h-28 w-28 shrink-0 overflow-hidden rounded border border-gray-200 bg-gray-50'>
           <Image
+            loader={productImageLoader}
             src={item.imageUrl}
             alt={item.name}
             fill

--- a/apps/presentation/lib/__tests__/product-image-loader.test.ts
+++ b/apps/presentation/lib/__tests__/product-image-loader.test.ts
@@ -1,0 +1,111 @@
+import { productImageLoader } from '../product-image-loader'
+
+const CT_HOST = 'https://images.eu-central-1.aws.commercetools.com/project'
+
+function load(src: string, width: number): string {
+  const loader = productImageLoader(src)
+  if (!loader) {
+    throw new Error(`No loader returned for src: ${src}`)
+  }
+  return loader({ src, width })
+}
+
+describe('productImageLoader', () => {
+  describe('host detection', () => {
+    it('returns a loader for the CT CDN host', () => {
+      expect(productImageLoader(`${CT_HOST}/image.jpg`)).toBeInstanceOf(
+        Function
+      )
+    })
+
+    it('returns undefined for a non-CT host', () => {
+      expect(
+        productImageLoader('https://storage.googleapis.com/bucket/image.jpg')
+      ).toBeUndefined()
+    })
+
+    it('returns undefined for a relative path', () => {
+      expect(productImageLoader('/images/product-image.png')).toBeUndefined()
+    })
+
+    it('returns undefined for an empty string', () => {
+      expect(productImageLoader('')).toBeUndefined()
+    })
+
+    it('accepts protocol-relative CT URLs', () => {
+      expect(
+        productImageLoader(
+          '//images.eu-central-1.aws.commercetools.com/project/image.jpg'
+        )
+      ).toBeInstanceOf(Function)
+    })
+  })
+
+  describe('size suffix breakpoints', () => {
+    const src = `${CT_HOST}/image.jpg`
+
+    it('selects -thumb at width ≤ 50', () => {
+      expect(load(src, 50)).toContain('-thumb')
+      expect(load(src, 1)).toContain('-thumb')
+    })
+
+    it('selects -small at width ≤ 150', () => {
+      expect(load(src, 150)).toContain('-small')
+      expect(load(src, 51)).toContain('-small')
+    })
+
+    it('selects -medium at width ≤ 400', () => {
+      expect(load(src, 400)).toContain('-medium')
+      expect(load(src, 151)).toContain('-medium')
+    })
+
+    it('selects -large at width ≤ 700', () => {
+      expect(load(src, 700)).toContain('-large')
+      expect(load(src, 401)).toContain('-large')
+    })
+
+    it('selects -zoom at width > 700', () => {
+      expect(load(src, 701)).toContain('-zoom')
+      expect(load(src, 1400)).toContain('-zoom')
+    })
+  })
+
+  describe('URL transformation', () => {
+    const width = 700 // -large
+
+    it('inserts suffix before the extension', () => {
+      expect(load(`${CT_HOST}/image.jpg`, width)).toBe(
+        `${CT_HOST}/image-large.jpg`
+      )
+    })
+
+    it('preserves query string after the suffix', () => {
+      expect(load(`${CT_HOST}/image.jpg?v=1`, width)).toBe(
+        `${CT_HOST}/image-large.jpg?v=1`
+      )
+    })
+
+    it('preserves a bare fragment (no query string)', () => {
+      expect(load(`${CT_HOST}/image.jpg#anchor`, width)).toBe(
+        `${CT_HOST}/image-large.jpg#anchor`
+      )
+    })
+
+    it('preserves both query string and fragment', () => {
+      expect(load(`${CT_HOST}/image.jpg?v=1#anchor`, width)).toBe(
+        `${CT_HOST}/image-large.jpg?v=1#anchor`
+      )
+    })
+
+    it('is a no-op for extensionless URLs', () => {
+      const src = `${CT_HOST}/image`
+      expect(load(src, width)).toBe(src)
+    })
+
+    it('handles .png extension', () => {
+      expect(load(`${CT_HOST}/image.png`, width)).toBe(
+        `${CT_HOST}/image-large.png`
+      )
+    })
+  })
+})

--- a/apps/presentation/lib/image-host-utils.ts
+++ b/apps/presentation/lib/image-host-utils.ts
@@ -1,0 +1,12 @@
+export function isHostSupported(
+  url: string,
+  hosts: readonly string[]
+): boolean {
+  try {
+    const absolute = url.startsWith('//') ? `https:${url}` : url
+    const host = new URL(absolute).hostname
+    return hosts.some((h) => host === h || host.endsWith('.' + h))
+  } catch {
+    return false
+  }
+}

--- a/apps/presentation/lib/product-image-loader.ts
+++ b/apps/presentation/lib/product-image-loader.ts
@@ -6,6 +6,7 @@
  */
 
 import { PRODUCT_IMAGE_HOSTS } from '@config/constants'
+import { isHostSupported } from './image-host-utils'
 
 const SIZE_BREAKPOINTS = [
   { maxWidth: 50, suffix: '-thumb' },
@@ -14,19 +15,9 @@ const SIZE_BREAKPOINTS = [
   { maxWidth: 700, suffix: '-large' },
 ] as const
 
-export type ProductImageLoaderParams = {
+type ProductImageLoaderParams = {
   src: string
   width: number
-}
-
-function productHostSupported(url: string): boolean {
-  try {
-    const absolute = url.startsWith('//') ? `https:${url}` : url
-    const host = new URL(absolute).hostname
-    return PRODUCT_IMAGE_HOSTS.some((h) => host === h || host.endsWith('.' + h))
-  } catch {
-    return false
-  }
 }
 
 function getSizeSuffix(width: number): string {
@@ -38,13 +29,20 @@ function getSizeSuffix(width: number): string {
   return '-zoom'
 }
 
-export function productImageLoader({
+function buildProductImageUrl({
   src,
   width,
 }: ProductImageLoaderParams): string {
-  if (!src || !productHostSupported(src)) {
-    return src
-  }
   const suffix = getSizeSuffix(width)
-  return src.replace(/(\.[^./?#]+)(\?.*)?$/, `${suffix}$1$2`)
+  // Captures extension, optional query string, and optional fragment separately
+  // so each is preserved after suffix insertion. No-op for extensionless URLs.
+  return src.replace(/(\.[^./?#]+)(\?[^#]*)?(#.*)?$/, `${suffix}$1$2$3`)
+}
+
+export function productImageLoader(
+  src: string
+): typeof buildProductImageUrl | undefined {
+  return isHostSupported(src, PRODUCT_IMAGE_HOSTS)
+    ? buildProductImageUrl
+    : undefined
 }

--- a/apps/presentation/lib/product-image-loader.ts
+++ b/apps/presentation/lib/product-image-loader.ts
@@ -1,0 +1,50 @@
+/**
+ * Next.js Image loader for commercetools product images.
+ * Transforms CDN URLs to use pre-generated size variants via filename suffix.
+ * @see https://nextjs.org/docs/app/api-reference/components/image#loader
+ * @see https://docs.commercetools.com/api/projects/products#image
+ */
+
+import { PRODUCT_IMAGE_HOSTS } from '@config/constants'
+
+const SIZE_BREAKPOINTS = [
+  { maxWidth: 50, suffix: '-thumb' },
+  { maxWidth: 150, suffix: '-small' },
+  { maxWidth: 400, suffix: '-medium' },
+  { maxWidth: 700, suffix: '-large' },
+] as const
+
+export type ProductImageLoaderParams = {
+  src: string
+  width: number
+}
+
+function productHostSupported(url: string): boolean {
+  try {
+    const absolute = url.startsWith('//') ? `https:${url}` : url
+    const host = new URL(absolute).hostname
+    return PRODUCT_IMAGE_HOSTS.some((h) => host === h || host.endsWith('.' + h))
+  } catch {
+    return false
+  }
+}
+
+function getSizeSuffix(width: number): string {
+  for (const { maxWidth, suffix } of SIZE_BREAKPOINTS) {
+    if (width <= maxWidth) {
+      return suffix
+    }
+  }
+  return '-zoom'
+}
+
+export function productImageLoader({
+  src,
+  width,
+}: ProductImageLoaderParams): string {
+  if (!src || !productHostSupported(src)) {
+    return src
+  }
+  const suffix = getSizeSuffix(width)
+  return src.replace(/(\.[^./?#]+)(\?.*)?$/, `${suffix}$1$2`)
+}

--- a/apps/presentation/next.config.ts
+++ b/apps/presentation/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from 'next'
 import createNextIntlPlugin from 'next-intl/plugin'
 import path from 'path'
-import { CONTENT_IMAGE_API_HOSTS } from '@config/constants'
+import { CONTENT_IMAGE_API_HOSTS, PRODUCT_IMAGE_HOSTS } from '@config/constants'
 
 const withNextIntl = createNextIntlPlugin()
 const svgLoader = {
@@ -36,11 +36,11 @@ const nextConfig: NextConfig = {
         hostname: 'storage.googleapis.com',
         pathname: '/**',
       },
-      {
-        protocol: 'https',
-        hostname: 'images.eu-central-1.aws.commercetools.com',
-        pathname: '/**',
-      },
+      ...PRODUCT_IMAGE_HOSTS.map((hostname) => ({
+        protocol: 'https' as const,
+        hostname,
+        pathname: '/**' as const,
+      })),
       ...CONTENT_IMAGE_API_HOSTS.map((hostname) => ({
         protocol: 'https' as const,
         hostname,

--- a/config/constants/src/index.ts
+++ b/config/constants/src/index.ts
@@ -43,5 +43,8 @@ export * from './cache'
 // Re-export content-image constants
 export * from './content-image'
 
+// Re-export product-image constants
+export * from './product-image'
+
 // Re-export search constants
 export * from './search'

--- a/config/constants/src/product-image.ts
+++ b/config/constants/src/product-image.ts
@@ -1,0 +1,8 @@
+/**
+ * Product/commerce image CDN hostnames. Used by next.config images.remotePatterns
+ * and by the presentation product image loader.
+ */
+
+export const PRODUCT_IMAGE_HOSTS = [
+  'images.eu-central-1.aws.commercetools.com',
+] as const


### PR DESCRIPTION
  Add productImageLoader (commercetools filename-suffix sizing) and wire
  contentImageLoader into the remaining Contentful image (lazy-video poster).