### PR TITLE
feat: improved accessibility, set default address improvement

### DIFF
--- a/apps/presentation/components/ui/__tests__/toast.test.tsx
+++ b/apps/presentation/components/ui/__tests__/toast.test.tsx
@@ -82,6 +82,26 @@ describe('Toast Component', () => {
       expect(toast).toHaveAttribute('aria-atomic', 'true')
     })
 
+    it('announces the error type assertively by default', () => {
+      render(<Toast type='error'>Error message</Toast>)
+
+      const toast = screen.getByRole('alert')
+      expect(toast).toHaveAttribute('aria-live', 'assertive')
+    })
+
+    it('allows the error type to opt out of assertive announcement', () => {
+      render(
+        <Toast
+          type='error'
+          critical={false}
+        >
+          Error message
+        </Toast>
+      )
+
+      expect(screen.getByRole('status')).toHaveAttribute('aria-live', 'polite')
+    })
+
     it('renders without icon when withIcon is false', () => {
       render(<Toast withIcon={false}>No icon message</Toast>)
 

--- a/apps/presentation/components/ui/toast.tsx
+++ b/apps/presentation/components/ui/toast.tsx
@@ -15,6 +15,7 @@ interface ToastProps {
   id?: string | number
   type?: 'info' | 'infoLight' | 'success' | 'error' | 'warning'
   duration?: number
+  /** Announce assertively (role="alert"). Defaults to true for the error type. */
   critical?: boolean
   withIcon?: boolean
   withCloseButton?: boolean
@@ -110,7 +111,7 @@ const types = cva(
 function Toast({
   type = 'info',
   id,
-  critical = false,
+  critical,
   withIcon = true,
   withCloseButton = true,
   className,
@@ -118,13 +119,15 @@ function Toast({
 }: React.PropsWithChildren<ToastProps>) {
   const t = useTranslations('common')
   const { icon: IconComponent, iconColorClass } = toastConfig[type ?? 'info']
+  // Errors interrupt the screen reader, everything else waits its turn
+  const isCritical = critical ?? type === 'error'
 
   return (
     <div
       className={cn(types({ type }), className)}
-      aria-live={critical ? 'assertive' : 'polite'}
+      aria-live={isCritical ? 'assertive' : 'polite'}
       aria-atomic='true'
-      role={critical ? 'alert' : 'status'}
+      role={isCritical ? 'alert' : 'status'}
     >
       <div className='flex flex-1 items-center'>
         <div className='flex w-full items-center gap-3 text-sm/[1.6] font-normal not-italic'>

--- a/apps/presentation/features/address/address-form.tsx
+++ b/apps/presentation/features/address/address-form.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useId } from 'react'
 import { useForm, Controller } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { useTranslations, useLocale } from 'next-intl'
@@ -17,7 +17,6 @@ import {
   type AddressRequest,
 } from '@core/contracts/address/address-base'
 import PlusIcon from '@/public/icons/plus.svg'
-import { Checkbox } from '@/components/ui/checkbox'
 import { Button } from '@/components/ui/button'
 import { getCountryOptions } from '@/features/address/address-utils'
 
@@ -40,11 +39,6 @@ export interface AddressFormProps {
    */
   formId?: string
   /**
-   * Whether to show checkboxes for setting default shipping/billing addresses
-   * Should be true when used in customer account area
-   */
-  showDefaultAddressOptions?: boolean
-  /**
    * Callback to notify parent component of form state changes
    */
   onStateChange?: (state: AddressFormState) => void
@@ -59,11 +53,11 @@ export function AddressForm({
   onSubmit,
   defaultValues,
   formId,
-  showDefaultAddressOptions = false,
   onStateChange,
   countries,
 }: AddressFormProps) {
   const t = useTranslations('address.form')
+  const fieldIdPrefix = useId()
   const locale = useLocale()
   const { storeConfig } = useStoreConfig()
   const rfcLocale = urlPrefixToRfc(locale)
@@ -106,8 +100,15 @@ export function AddressForm({
           render={({ field, fieldState }) => (
             <Field data-invalid={fieldState.invalid}>
               <div className='space-y-2'>
+                <span
+                  id={`${fieldIdPrefix}-salutation-label`}
+                  className='block text-xs/[1.5] text-gray-500'
+                >
+                  {t('fields.salutation')}
+                </span>
                 <RadioGroup
-                  id='salutation'
+                  id={`${fieldIdPrefix}-salutation`}
+                  aria-labelledby={`${fieldIdPrefix}-salutation-label`}
                   orientation='horizontal'
                   value={field.value || ''}
                   onValueChange={field.onChange}
@@ -120,12 +121,12 @@ export function AddressForm({
                     >
                       <RadioGroupItem
                         value={salutation}
-                        id={`salutation-${salutation}`}
-                        aria-labelledby={`salutation-${salutation}-label`}
+                        id={`${fieldIdPrefix}-salutation-${salutation}`}
+                        aria-labelledby={`${fieldIdPrefix}-salutation-${salutation}-label`}
                         invalid={fieldState.invalid}
                       />
                       <span
-                        id={`salutation-${salutation}-label`}
+                        id={`${fieldIdPrefix}-salutation-${salutation}-label`}
                         className='text-base text-gray-700 capitalize'
                       >
                         {t(`salutationOptions.${salutation}`)}
@@ -201,6 +202,7 @@ export function AddressForm({
               {...field}
               id='streetNumber'
               label={t('fields.streetNumber')}
+              required
               autoComplete='address-line2'
               validationState={validationState}
             />
@@ -314,56 +316,6 @@ export function AddressForm({
           }}
         />
       </Field>
-
-      {/* Default Address Options - Only shown in customer area */}
-      {showDefaultAddressOptions && (
-        <div className='space-y-3 border-t border-gray-200 pt-4'>
-          <Field>
-            <Controller
-              name='isDefaultShipping'
-              control={form.control}
-              render={({ field }) => (
-                <label className='flex cursor-pointer items-center gap-3'>
-                  <Checkbox
-                    id='isDefaultShipping'
-                    aria-labelledby='isDefaultShipping-label'
-                    checked={field.value || false}
-                    onCheckedChange={field.onChange}
-                  />
-                  <span
-                    id='isDefaultShipping-label'
-                    className='text-sm font-medium text-gray-700'
-                  >
-                    {t('defaultShipping')}
-                  </span>
-                </label>
-              )}
-            />
-          </Field>
-          <Field>
-            <Controller
-              name='isDefaultBilling'
-              control={form.control}
-              render={({ field }) => (
-                <label className='flex cursor-pointer items-center gap-3'>
-                  <Checkbox
-                    id='isDefaultBilling'
-                    aria-labelledby='isDefaultBilling-label'
-                    checked={field.value || false}
-                    onCheckedChange={field.onChange}
-                  />
-                  <span
-                    id='isDefaultBilling-label'
-                    className='text-sm font-medium text-gray-700'
-                  >
-                    {t('defaultBilling')}
-                  </span>
-                </label>
-              )}
-            />
-          </Field>
-        </div>
-      )}
     </form>
   )
 }

--- a/apps/presentation/features/address/address-utils.ts
+++ b/apps/presentation/features/address/address-utils.ts
@@ -144,15 +144,11 @@ export function findMatchingAddressId(
  * Generates default values for address form fields.
  * @param address - Optional address to populate form fields (for editing)
  * @param customer - Optional customer data to populate default values
- * @param defaultShippingAddressId - Optional default shipping address ID
- * @param defaultBillingAddressId - Optional default billing address ID
  * @returns Default values object for the form
  */
 export function getAddressFormDefaultValues(
   address?: AddressResponse,
-  customer?: CustomerResponse,
-  defaultShippingAddressId?: string,
-  defaultBillingAddressId?: string
+  customer?: CustomerResponse
 ): Partial<AddAddressRequest | UpdateAddressRequest> {
   // Use customer defaults only when creating a new address (no address provided)
   const useCustomerDefaults = !address
@@ -177,11 +173,5 @@ export function getAddressFormDefaultValues(
     postalCode: address?.postalCode || '',
     city: address?.city || '',
     email: address?.email || customer?.email || '',
-    isDefaultShipping: address?.id
-      ? address.id === defaultShippingAddressId
-      : false,
-    isDefaultBilling: address?.id
-      ? address.id === defaultBillingAddressId
-      : false,
   }
 }

--- a/apps/presentation/features/checkout/components/address-step/address-step-manage-addresses-modal.tsx
+++ b/apps/presentation/features/checkout/components/address-step/address-step-manage-addresses-modal.tsx
@@ -15,6 +15,7 @@ import {
 } from '@/components/ui/sheet'
 import { AddressForm } from '@/features/address/address-form'
 import { CustomerAddressItem } from '@/features/customer/customer-address-item'
+import { CustomerAddressDefaultActions } from '@/features/customer/customer-address-default-actions'
 import {
   AddressResponse,
   AddAddressRequest,
@@ -77,9 +78,6 @@ export function AddressStepManageAddressesModal({
   const handleFormSubmit = async (data: AddressBase) => {
     const addressData = {
       ...data,
-      // Ensure default address options are always booleans
-      isDefaultShipping: data.isDefaultShipping ?? false,
-      isDefaultBilling: data.isDefaultBilling ?? false,
       ...(formMode?.type === 'editing' && { id: formMode.address.id }),
     }
 
@@ -146,23 +144,34 @@ export function AddressStepManageAddressesModal({
             <ErrorDisplay>{t('addresses.loadError')}</ErrorDisplay>
           )}
           {!isLoading && !error && formMode && (
-            <AddressForm
-              key={
-                formMode.type === 'editing'
-                  ? formMode.address.id
-                  : 'new-address'
-              }
-              formId='customer-address-form'
-              showDefaultAddressOptions={true}
-              defaultValues={getAddressFormDefaultValues(
-                formMode.type === 'editing' ? formMode.address : undefined,
-                customer,
-                defaultShippingAddressId,
-                defaultBillingAddressId
+            <>
+              <AddressForm
+                key={
+                  formMode.type === 'editing'
+                    ? formMode.address.id
+                    : 'new-address'
+                }
+                formId='customer-address-form'
+                defaultValues={getAddressFormDefaultValues(
+                  formMode.type === 'editing' ? formMode.address : undefined,
+                  customer
+                )}
+                onStateChange={setFormState}
+                onSubmit={handleFormSubmit}
+              />
+              {formMode.type === 'editing' && (
+                <CustomerAddressDefaultActions
+                  addressId={formMode.address.id}
+                  isDefaultShipping={
+                    formMode.address.id === defaultShippingAddressId
+                  }
+                  isDefaultBilling={
+                    formMode.address.id === defaultBillingAddressId
+                  }
+                  className='mt-6 border-t border-gray-200 pt-4'
+                />
               )}
-              onStateChange={setFormState}
-              onSubmit={handleFormSubmit}
-            />
+            </>
           )}
           {!isLoading && !error && !formMode && (
             <>

--- a/apps/presentation/features/customer/customer-address-default-actions.tsx
+++ b/apps/presentation/features/customer/customer-address-default-actions.tsx
@@ -1,0 +1,87 @@
+'use client'
+
+import { FC } from 'react'
+import { useTranslations } from 'next-intl'
+import { Badge } from '@/components/ui/badge/badge'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+import { useCustomerAddressOperations } from './customer-use-customer-address-operations'
+import TruckIcon from '@/public/icons/delivery-truck.svg'
+import CoinsIcon from '@/public/icons/coins.svg'
+
+interface CustomerAddressDefaultActionsProps {
+  addressId?: string
+  isDefaultShipping: boolean
+  isDefaultBilling: boolean
+  className?: string
+}
+
+/**
+ * Default shipping/billing controls for a single address.
+ * Shows a badge when the address already is the default, a button to set it otherwise.
+ */
+export const CustomerAddressDefaultActions: FC<
+  CustomerAddressDefaultActionsProps
+> = ({ addressId, isDefaultShipping, isDefaultBilling, className }) => {
+  const t = useTranslations('account.myAccount')
+  const {
+    handleSetDefaultShipping,
+    handleSetDefaultBilling,
+    isSetDefaultShippingPending,
+    isSetDefaultBillingPending,
+  } = useCustomerAddressOperations()
+
+  const onSetDefaultShipping = async () => {
+    if (addressId) {
+      await handleSetDefaultShipping(addressId)
+    }
+  }
+
+  const onSetDefaultBilling = async () => {
+    if (addressId) {
+      await handleSetDefaultBilling(addressId)
+    }
+  }
+
+  return (
+    <div
+      className={cn(
+        'flex flex-wrap items-center justify-between gap-2',
+        className
+      )}
+    >
+      {isDefaultShipping ? (
+        <Badge variant='gray'>{t('addresses.defaultShipping')}</Badge>
+      ) : (
+        <Button
+          type='button'
+          variant='tertiary'
+          scheme='black'
+          size='auto'
+          className='h-auto py-1 text-xs'
+          onClick={onSetDefaultShipping}
+          disabled={isSetDefaultShippingPending}
+        >
+          <TruckIcon className='size-4' />
+          {t('addresses.setDefaultShipping')}
+        </Button>
+      )}
+      {isDefaultBilling ? (
+        <Badge variant='gray'>{t('addresses.defaultBilling')}</Badge>
+      ) : (
+        <Button
+          type='button'
+          variant='tertiary'
+          scheme='black'
+          size='auto'
+          className='h-auto py-1 text-xs'
+          onClick={onSetDefaultBilling}
+          disabled={isSetDefaultBillingPending}
+        >
+          <CoinsIcon className='size-4' />
+          {t('addresses.setDefaultBilling')}
+        </Button>
+      )}
+    </div>
+  )
+}

--- a/apps/presentation/features/customer/customer-address-item.tsx
+++ b/apps/presentation/features/customer/customer-address-item.tsx
@@ -4,14 +4,12 @@ import { Button } from '@/components/ui/button'
 import { useCustomerAddressOperations } from './customer-use-customer-address-operations'
 import { AddressResponse } from '@core/contracts/customer/address'
 import { useTranslations } from 'next-intl'
-import { FC, useState } from 'react'
+import { FC, useId, useState } from 'react'
 import PencilIcon from '@/public/icons/pencil.svg'
 import TrashIcon from '@/public/icons/trash-bin.svg'
-import TruckIcon from '@/public/icons/delivery-truck.svg'
-import CoinsIcon from '@/public/icons/coins.svg'
 import { cn } from '@/lib/utils'
-import { Badge } from '@/components/ui/badge/badge'
 import { CustomerAddressRemovalConfirmation } from './components/customer-address-removal-confirmation'
+import { CustomerAddressDefaultActions } from './customer-address-default-actions'
 import { useFormatAddressLines } from '@/features/address/use-format-address-lines'
 import { Card } from '@/components/ui/card'
 
@@ -30,14 +28,9 @@ export const CustomerAddressItem: FC<CustomerAddressItemProps> = ({
 }) => {
   const t = useTranslations('account.myAccount')
   const [showDeleteConfirmation, setShowDeleteConfirmation] = useState(false)
-  const {
-    handleDeleteConfirm,
-    handleSetDefaultShipping,
-    handleSetDefaultBilling,
-    isDeleteAddressPending,
-    isSetDefaultShippingPending,
-    isSetDefaultBillingPending,
-  } = useCustomerAddressOperations()
+  const addressLabelId = useId()
+  const { handleDeleteConfirm, isDeleteAddressPending } =
+    useCustomerAddressOperations()
 
   const handleDeleteClick = () => setShowDeleteConfirmation(true)
 
@@ -52,22 +45,12 @@ export const CustomerAddressItem: FC<CustomerAddressItemProps> = ({
 
   const handleDeleteCancel = () => setShowDeleteConfirmation(false)
 
-  const onSetDefaultShipping = async () => {
-    if (address.id) {
-      await handleSetDefaultShipping(address.id)
-    }
-  }
-
-  const onSetDefaultBilling = async () => {
-    if (address.id) {
-      await handleSetDefaultBilling(address.id)
-    }
-  }
-
   const addressLines = useFormatAddressLines(address)
 
   return (
     <Card
+      role='group'
+      aria-labelledby={addressLabelId}
       scheme={isDefaultShipping || isDefaultBilling ? 'gray' : 'white'}
       className={cn('relative flex flex-col justify-between border', {
         'border-transparent': isDefaultShipping || isDefaultBilling,
@@ -84,7 +67,10 @@ export const CustomerAddressItem: FC<CustomerAddressItemProps> = ({
       )}
 
       <div className='mb-4 flex flex-col gap-4 sm:mb-8 sm:flex-row sm:justify-between sm:gap-2'>
-        <div className='space-y-1 text-sm text-gray-900'>
+        <div
+          id={addressLabelId}
+          className='space-y-1 text-sm text-gray-900'
+        >
           {addressLines.map((line, index) => (
             <div
               key={index}
@@ -119,40 +105,12 @@ export const CustomerAddressItem: FC<CustomerAddressItemProps> = ({
         </div>
       </div>
 
-      <div className='flex flex-wrap items-center justify-between gap-2 border-t border-gray-200 pt-4'>
-        {isDefaultShipping ? (
-          <Badge variant='gray'>{t('addresses.defaultShipping')}</Badge>
-        ) : (
-          <Button
-            variant='tertiary'
-            scheme='black'
-            size='auto'
-            className='h-auto py-1 text-xs'
-            onClick={onSetDefaultShipping}
-            disabled={isSetDefaultShippingPending}
-            aria-label={t('addresses.setDefaultShipping')}
-          >
-            <TruckIcon className='size-4' />
-            {t('addresses.setDefaultShipping')}
-          </Button>
-        )}
-        {isDefaultBilling ? (
-          <Badge variant='gray'>{t('addresses.defaultBilling')}</Badge>
-        ) : (
-          <Button
-            variant='tertiary'
-            scheme='black'
-            size='auto'
-            className='h-auto py-1 text-xs'
-            onClick={onSetDefaultBilling}
-            disabled={isSetDefaultBillingPending}
-            aria-label={t('addresses.setDefaultBilling')}
-          >
-            <CoinsIcon className='size-4' />
-            {t('addresses.setDefaultBilling')}
-          </Button>
-        )}
-      </div>
+      <CustomerAddressDefaultActions
+        addressId={address.id}
+        isDefaultShipping={isDefaultShipping}
+        isDefaultBilling={isDefaultBilling}
+        className='border-t border-gray-200 pt-4'
+      />
     </Card>
   )
 }

--- a/apps/presentation/features/customer/customer-addresses.tsx
+++ b/apps/presentation/features/customer/customer-addresses.tsx
@@ -19,6 +19,7 @@ import {
 } from '@/components/ui/sheet'
 import { AddressForm } from '@/features/address/address-form'
 import { CustomerAddressItem } from './customer-address-item'
+import { CustomerAddressDefaultActions } from './customer-address-default-actions'
 import {
   AddressResponse,
   UpdateAddressRequest,
@@ -71,8 +72,6 @@ export const CustomerAddresses: FC = () => {
     const isEditing = !!editingAddress
     const addressData = {
       ...data,
-      isDefaultShipping: data.isDefaultShipping ?? false,
-      isDefaultBilling: data.isDefaultBilling ?? false,
       ...(editingAddress && { id: editingAddress.id }),
     }
     const cleanedData = cleanAddressData(addressData, isEditing)
@@ -154,16 +153,25 @@ export const CustomerAddresses: FC = () => {
               <AddressForm
                 key={editingAddress?.id || 'new-address'}
                 formId='customer-address-form'
-                showDefaultAddressOptions={true}
                 defaultValues={getAddressFormDefaultValues(
                   editingAddress,
-                  customer,
-                  defaultShippingAddressId,
-                  defaultBillingAddressId
+                  customer
                 )}
                 onStateChange={setFormState}
                 onSubmit={handleFormSubmit}
               />
+              {editingAddress && (
+                <CustomerAddressDefaultActions
+                  addressId={editingAddress.id}
+                  isDefaultShipping={
+                    editingAddress.id === defaultShippingAddressId
+                  }
+                  isDefaultBilling={
+                    editingAddress.id === defaultBillingAddressId
+                  }
+                  className='mt-6 border-t border-gray-200 pt-4'
+                />
+              )}
             </SheetBody>
             <SheetFooter>
               <Button

--- a/core/contracts/src/address/address-base.ts
+++ b/core/contracts/src/address/address-base.ts
@@ -51,6 +51,7 @@ export const AddressRequestSchema = AddressBaseSchema.required({
   email: true,
   country: true,
   streetName: true,
+  streetNumber: true,
   postalCode: true,
   city: true,
 })


### PR DESCRIPTION
- Default shipping/billing checkboxes in the address flyout replaced with buttons (shared with the address list) — unchecking a checkbox previously showed a success toast without clearing the default
- Address cards are now role="group" labelled by the address, so Edit/Delete have identifying accessible names
- Salutation radio group now has a visible, associated label; salutation element ids scoped per form
- Error toasts announce assertively (role="alert")
- Street number is now genuinely required (schema + form) instead of failing validation on a field marked optional